### PR TITLE
add matchtagtobool feature + fix abilities not ending after checking tags

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -143,7 +143,8 @@ void UGMCAbility::BeginAbility()
 {
 	// Check Activation Tags
 	if (!CheckActivationTags()){
-		UE_LOG(LogGMCAbilitySystem, Warning, TEXT("Ability Activation Stopped By Tags"));
+		UE_LOG(LogGMCAbilitySystem, Verbose, TEXT("Ability Activation for %s Stopped By Tags"), *AbilityTag.ToString());
+		EndAbility();
 		return;
 	}
 	

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -89,6 +89,14 @@ public:
 
 	void QueueTaskData(const FInstancedStruct& TaskData);
 
+	/**
+	 * Will add/remove a given gameplay tag to the ASC based on the bool inputted.
+	 * Call this function on Prediction Tick.
+	 * A good example of this is something like a State.InAir tag.
+	 */
+	UFUNCTION(BlueprintCallable)
+	void MatchTagToBool(FGameplayTag InTag, bool MatchedBool);
+
 	// A UGMCAttributesData asset that defines the default attributes for this component
 	UPROPERTY(EditDefaultsOnly, DisplayName="Attributes")
 	TArray<UGMCAttributesData*> AttributeDataAssets; 
@@ -141,6 +149,10 @@ public:
 
 	/** Get an Attribute using its Tag */
 	const FAttribute* GetAttributeByTag(FGameplayTag AttributeTag) const;
+
+	/** Get the default value of an attribute from the data assets. */
+	UFUNCTION(BlueprintCallable)
+	float GetDefaultAttributeValueByTag(FGameplayTag AttributeTag) const;
 	
 	// Apply modifiers that affect attributes
 	UFUNCTION(BlueprintCallable)


### PR DESCRIPTION
Adds a function that the user can call in MovementUpdate/PredictionTick that will apply the corresponding tag to the ASC according to the value of the bool. Also fixed a bug where abilities wouldn't end even if there was a blocked tag or they were missing a needed tag. They wouldn't call begin but they wouldn't end or get gc'd either.