### PR TITLE
Adding Attribute Modifiers

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -298,8 +298,10 @@ void UGMC_AbilitySystemComponent::InstantiateAttributes()
 		for(const FAttributeData AttributeData : AttributeDataAsset->AttributeData){
 			FAttribute NewAttribute;
 			NewAttribute.Tag = AttributeData.AttributeTag;
-			NewAttribute.Value = AttributeData.DefaultValue;
+			NewAttribute.BaseValue = AttributeData.DefaultValue;
 			NewAttribute.bIsGMCBound = AttributeData.bGMCBound;
+			NewAttribute.CalculateValue();
+			
 			if(AttributeData.bGMCBound){
 				BoundAttributes.GetMutable<FGMCAttributeSet>().AddAttribute(NewAttribute);
 			}
@@ -620,6 +622,7 @@ const FAttribute* UGMC_AbilitySystemComponent::GetAttributeByTag(FGameplayTag At
 	const FAttribute** FoundAttribute = AllAttributes.FindByPredicate([AttributeTag](const FAttribute* Attribute){
 		return Attribute->Tag.MatchesTagExact(AttributeTag);
 	});
+	
 	if(FoundAttribute && *FoundAttribute){
 		return *FoundAttribute;
 	}
@@ -714,12 +717,9 @@ void UGMC_AbilitySystemComponent::ApplyAbilityEffectModifier(FGMCAttributeModifi
 		
 		if (bNegateValue)
 		{
-			AffectedAttribute->Value += -AttributeModifier.Value;
+			AttributeModifier.Value = -AttributeModifier.Value;
 		}
-		else
-		{
-			AffectedAttribute->Value += AttributeModifier.Value;
-		}
+		AffectedAttribute->ApplyModifier(AttributeModifier);
 
 		OnAttributeChanged.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
 	}

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -26,22 +26,31 @@ enum class EEffectState : uint8
 	Ended  // Lasts forever
 };
 
+UENUM(BlueprintType)
+enum class EModifierType : uint8
+{
+	// Adds to value
+	Add,
+	// Adds to value multiplier. Base Multiplier is 1. A modifier value of 1 will double the value.
+	Multiply,
+	// Adds to value divisor. Base Divisor is 1. A modifier value of 1 will halve the value.
+	Divide     
+};
+
 USTRUCT(BlueprintType)
 struct FGMCAttributeModifier
 {
 	GENERATED_BODY()
-
-	FGMCAttributeModifier()
-	{
-		Value = 0;
-	}
 		
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="Attribute", meta = (Categories="Attribute"))
 	FGameplayTag AttributeTag;
 
 	// Value to modify the attribute by
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
-	float Value;
+	float Value{0};
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	EModifierType ModifierType{EModifierType::Add};
 
 	// Metadata tags to be passed with the attribute
 	// Ie: DamageType (Element.Fire, Element.Electric), DamageSource (Source.Player, Source.Boss), etc


### PR DESCRIPTION
This is my initial stab at doing attribute modifiers.

The following modifiers exist:
```
Add
Multiply
Divide
```

The Attribute now keeps track of its BaseValue, an AdditiveMultiplier, a MultiplyModifier, and a DivideModifier. 

Additive Multiplier starts at 0, Multiply and Divide start at 1.

When you apply an Add effect, it just adds or subtracts from the Additive value.

For Multiply/Divide, the same is true. If you apply an effect with a Multiply type and a value of 1, it will add 1 to the MultiplyModifier. This would result in doubling the value. Which is weird if you don't know it, but I think it's the easiest way to add this.

The actual Value calc is done with:

```cpp
Value = (AdditiveModifier + (BaseValue * MultiplyModifier)) / DivideModifier;
```

(There are checks that happen before the calc to make sure Multiply/Divide modifiers aren't negative, and prevent divide by 0)

So say you have 100 base value, and you have a +1 mod to multiply and divide, you would get a total value of BaseValue. 

```
Value = (0 + (100 * 2)) / 2
Value = 200 / 2
Value = 100
```

I think there's a few ways that Value calc can be done, and I'm not sure any one is objectively correct, but this is my first stab at it.