### PR TITLE
Tag Change Delegates

### DIFF
--- a/GMCAbilitySystem.uplugin
+++ b/GMCAbilitySystem.uplugin
@@ -23,10 +23,12 @@
 		{
 			"Name": "GMCAbilitySystemTypesInclude",
 			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"WhitelistPlatforms": [
-				"Win64"
-			]
+			"LoadingPhase": "Default"
+		},
+		{
+			"Name": "GMCAbilitySystemEditor",
+			"Type": "Editor",
+			"LoadingPhase": "Default"
 		}
 	],
 	"Plugins": [

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForGameplayTagChange.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForGameplayTagChange.cpp
@@ -4,7 +4,7 @@
 #include "Ability/Tasks/WaitForGameplayTagChange.h"
 
 UGMCAbilityTask_WaitForGameplayTagChange* UGMCAbilityTask_WaitForGameplayTagChange::WaitForGameplayTagChange(
-	UGMCAbility* OwningAbility, FGameplayTagContainer WatchedTags, EGMCWaitForGameplayTagChangeType ChangeType)
+	UGMCAbility* OwningAbility, const FGameplayTagContainer& WatchedTags, EGMCWaitForGameplayTagChangeType ChangeType)
 {
 	UGMCAbilityTask_WaitForGameplayTagChange* Task = NewAbilityTask<UGMCAbilityTask_WaitForGameplayTagChange>(OwningAbility);
 	Task->Tags = WatchedTags;
@@ -19,8 +19,8 @@ void UGMCAbilityTask_WaitForGameplayTagChange::Activate()
 	Ability->OwnerAbilityComponent->AddFilteredTagChangeDelegate(Tags, FGameplayTagFilteredMulticastDelegate::FDelegate::CreateUObject(this, &UGMCAbilityTask_WaitForGameplayTagChange::OnGameplayTagChanged));
 }
 
-void UGMCAbilityTask_WaitForGameplayTagChange::OnGameplayTagChanged(FGameplayTagContainer AddedTags,
-	FGameplayTagContainer RemovedTags)
+void UGMCAbilityTask_WaitForGameplayTagChange::OnGameplayTagChanged(const FGameplayTagContainer& AddedTags,
+	const FGameplayTagContainer& RemovedTags)
 {
 	FGameplayTagContainer MatchedTags;
 	

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForGameplayTagChange.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForGameplayTagChange.cpp
@@ -1,0 +1,48 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Ability/Tasks/WaitForGameplayTagChange.h"
+
+UGMCAbilityTask_WaitForGameplayTagChange* UGMCAbilityTask_WaitForGameplayTagChange::WaitForGameplayTagChange(
+	UGMCAbility* OwningAbility, FGameplayTagContainer WatchedTags, EGMCWaitForGameplayTagChangeType ChangeType)
+{
+	UGMCAbilityTask_WaitForGameplayTagChange* Task = NewAbilityTask<UGMCAbilityTask_WaitForGameplayTagChange>(OwningAbility);
+	Task->Tags = WatchedTags;
+	Task->ChangeType = ChangeType;
+	return Task;
+}
+
+void UGMCAbilityTask_WaitForGameplayTagChange::Activate()
+{
+	Super::Activate();
+
+	Ability->OwnerAbilityComponent->AddFilteredTagChangeDelegate(Tags, FGameplayTagFilteredMulticastDelegate::FDelegate::CreateUObject(this, &UGMCAbilityTask_WaitForGameplayTagChange::OnGameplayTagChanged));
+}
+
+void UGMCAbilityTask_WaitForGameplayTagChange::OnGameplayTagChanged(FGameplayTagContainer AddedTags,
+	FGameplayTagContainer RemovedTags)
+{
+	FGameplayTagContainer MatchedTags;
+	
+	switch (ChangeType)
+	{
+		case Set:
+			MatchedTags = AddedTags.Filter(Tags);
+			break;
+
+		case Unset:
+			MatchedTags = AddedTags.Filter(Tags);
+			break;
+
+		case Changed:
+			MatchedTags = AddedTags.Filter(Tags);
+			MatchedTags.AppendTags(RemovedTags.Filter(Tags));
+			break;
+	}
+
+	if (!MatchedTags.IsEmpty())
+	{
+		Completed.Broadcast(MatchedTags);
+		EndTask();
+	}
+}

--- a/Source/GMCAbilitySystem/Private/Animation/GMCAbilityAnimInstance.cpp
+++ b/Source/GMCAbilitySystem/Private/Animation/GMCAbilityAnimInstance.cpp
@@ -1,0 +1,18 @@
+﻿#include "Animation/GMCAbilityAnimInstance.h"
+#include "GMCAbilityComponent.h"
+
+void UGMCAbilityAnimInstance::NativeInitializeAnimation()
+{
+	if (const AActor* OwnerActor = GetOwningActor())
+	{
+		AbilitySystemComponent = Cast<UGMC_AbilitySystemComponent>(OwnerActor->GetComponentByClass(UGMC_AbilitySystemComponent::StaticClass()));
+		if (AbilitySystemComponent)
+		{
+			TagPropertyMap.Initialize(this, AbilitySystemComponent);
+		}
+	}
+
+	// As the super call will trigger the blueprint initialize event, we want to do it *after* we've set our
+	// Ability System Component.
+	Super::NativeInitializeAnimation();
+}

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -46,7 +46,7 @@ FDelegateHandle UGMC_AbilitySystemComponent::AddFilteredTagChangeDelegate(const 
 void UGMC_AbilitySystemComponent::RemoveFilteredTagChangeDelegate(const FGameplayTagContainer& Tags,
 	FDelegateHandle Handle)
 {
-	for (int32 Index = 0; Index < FilteredTagDelegates.Num(); Index++)
+	for (int32 Index = FilteredTagDelegates.Num() - 1; Index >= 0; --Index)
 	{
 		TPair<FGameplayTagContainer, FGameplayTagFilteredMulticastDelegate>& SearchPair = FilteredTagDelegates[Index];
 		if (SearchPair.Key == Tags)

--- a/Source/GMCAbilitySystem/Private/Utility/GameplayElementMapping.cpp
+++ b/Source/GMCAbilitySystem/Private/Utility/GameplayElementMapping.cpp
@@ -1,0 +1,234 @@
+﻿#include "Utility/GameplayElementMapping.h"
+#include "GMCAbilityComponent.h"
+#include "Misc/DataValidation.h"
+
+FGMCGameplayElementTagPropertyMap::FGMCGameplayElementTagPropertyMap()
+{
+}
+
+FGMCGameplayElementTagPropertyMap::FGMCGameplayElementTagPropertyMap(const FGMCGameplayElementTagPropertyMap& Other)
+{
+	ensureMsgf(Other.CachedOwner.IsExplicitlyNull(), TEXT("Tag property maps are invalid in arrays or copy-after-register scenarios."));
+	PropertyMappings = Other.PropertyMappings;
+}
+
+FGMCGameplayElementTagPropertyMap::~FGMCGameplayElementTagPropertyMap()
+{
+	Unregister();
+}
+
+#if WITH_EDITOR
+EDataValidationResult FGMCGameplayElementTagPropertyMap::IsDataValid(const UObject* ContainingAsset,
+	FDataValidationContext& Context) const
+{
+	UClass* OwnerClass = ((ContainingAsset != nullptr) ? ContainingAsset->GetClass() : nullptr);
+	if (!OwnerClass)
+	{
+		UE_LOG(LogGMCAbilitySystem, Error, TEXT("FGMCGameplayElementTagPropertyMap: called with invalid owner."))
+		return EDataValidationResult::Invalid;
+	}
+
+	for (const auto& Mapping : PropertyMappings)
+	{
+		for (auto& Tag : Mapping.TagsToMap)
+		{
+			if (!Tag.IsValid())
+			{
+				Context.AddError(FText::Format(FText::FromString("FGMCGameplayElementTagPropertyMap: tag {0} is invalid, but mapped to {1}"),
+					FText::FromString(Tag.ToString()), FText::FromName(Mapping.PropertyName) 
+					));
+			}
+		}
+
+		if (const FProperty* OwnerProperty = OwnerClass->FindPropertyByName(Mapping.PropertyName))
+		{
+			if (!IsPropertyTypeValid(OwnerProperty))
+			{
+				Context.AddError(FText::Format(FText::FromString("FGMCGameplayElementTagPropertyMap: tag {0} is mapped to property {1}, but property is an unsupported type"),
+					FText::FromString(Mapping.TagsToMap.ToString()), FText::FromName(Mapping.PropertyName)));
+			}
+		}
+		else
+		{
+			Context.AddError(FText::Format(FText::FromString("FGMCGameplayElementTagPropertyMap: tag {0} is mapped to nonexistent property {1}"),
+				FText::FromString(Mapping.TagsToMap.ToString()), FText::FromName(Mapping.PropertyName)));
+		}
+	}
+
+	return (Context.GetNumErrors() > 0 ? EDataValidationResult::Invalid : EDataValidationResult::Valid);
+}
+
+bool FGMCGameplayElementTagPropertyMap::SetValueForMappedProperty(FProperty* Property, FGameplayTagContainer& MatchedTags)
+{
+	UObject* Owner = CachedOwner.Get();
+
+	// We take the matched tags in case we someday want to change this to also support setting an array of matched tags
+	// on a property, or something similar.
+	const int32 Value = MatchedTags.Num();
+	
+	if (!Property || !Owner)
+	{
+		return false;
+	}
+
+	if (const FBoolProperty* BoolProperty = Cast<FBoolProperty>(Property))
+	{
+		BoolProperty->SetPropertyValue_InContainer(Owner, Value > 0);
+		return true;
+	}
+
+	if (const FIntProperty* IntProperty = Cast<FIntProperty>(Property))
+	{
+		IntProperty->SetPropertyValue_InContainer(Owner, Value);
+		return true;
+	}
+
+	if (const FFloatProperty* FloatProperty = Cast<FFloatProperty>(Property))
+	{
+		FloatProperty->SetPropertyValue_InContainer(Owner, Value);
+		return true;
+	}
+
+	if (const FDoubleProperty* DoubleProperty = Cast<FDoubleProperty>(Property))
+	{
+		DoubleProperty->SetPropertyValue_InContainer(Owner, Value);
+		return true;
+	}
+
+	return false;
+}
+#endif
+
+void FGMCGameplayElementTagPropertyMap::Initialize(UObject* Owner, UGMC_AbilitySystemComponent* AbilitySystemComponent)
+{
+	UClass *OwnerClass = (Owner ? Owner->GetClass() : nullptr);
+	if (!OwnerClass)
+	{
+		UE_LOG(LogGMCAbilitySystem, Error, TEXT("FGMCGameplayElementTagPropertyMap::Initialize() called with invalid owner."));
+		return;
+	}
+
+	if (!AbilitySystemComponent)
+	{
+		UE_LOG(LogGMCAbilitySystem, Error, TEXT("FGMCGameplayElementTagPropertyMap::Initialize() called with invalid ability component"));
+		return;
+	}
+
+	if ((CachedOwner == Owner) && (CachedAbilityComponent == AbilitySystemComponent))
+	{
+		// Already initialized for this setup, just exit.
+		return;
+	}
+
+	if (CachedOwner.IsValid())
+	{
+		// Changing owners, unregister all current delegates.
+		Unregister();
+	}
+
+	CachedOwner = Owner;
+	CachedAbilityComponent = AbilitySystemComponent;
+
+	FGameplayTagFilteredMulticastDelegate::FDelegate Delegate = FGameplayTagFilteredMulticastDelegate::FDelegate::CreateRaw(this, &FGMCGameplayElementTagPropertyMap::GameplayTagChangedCallback);
+
+	for (int Index = PropertyMappings.Num() - 1; Index >= 0; --Index)
+	{
+		auto& Mapping = PropertyMappings[Index];
+		if (Mapping.TagsToMap.IsValid())
+		{
+			FProperty* Property = OwnerClass->FindPropertyByName(Mapping.PropertyName);
+			if (Property && IsPropertyTypeValid(Property))
+			{
+				Mapping.PropertyToMap = Property;
+				Mapping.DelegateHandle = AbilitySystemComponent->AddFilteredTagChangeDelegate(Mapping.TagsToMap, Delegate);
+				continue;
+			}
+		}
+
+		// We're invalid, so remove.
+		UE_LOG(LogGMCAbilitySystem, Error, TEXT("FGMCGameplayElementTagPropertyMap: Removing invalid mapping [index %d, tags %s, property %s] for %s"),
+			Index, *Mapping.TagsToMap.ToString(), *Mapping.PropertyName.ToString(), *GetNameSafe(Owner));
+		PropertyMappings.RemoveAtSwap(Index, 1, false);
+	}
+
+	ApplyCurrentTags();
+}
+
+void FGMCGameplayElementTagPropertyMap::ApplyCurrentTags()
+{
+	UObject* Owner = CachedOwner.Get();
+	UGMC_AbilitySystemComponent* AbilityComponent = CachedAbilityComponent.Get();
+
+	if (!Owner)
+	{
+		UE_LOG(LogGMCAbilitySystem, Warning, TEXT("FGMCGameplayElementTagPropertyMap::ApplyCurrentTags() called with invalid owner."));
+		return;
+	}
+
+	if (!AbilityComponent)
+	{
+		UE_LOG(LogGMCAbilitySystem, Warning, TEXT("FGMCGameplayElementTagPropertyMap::ApplyCurrentTags() called with invalid ability component."));
+		return;
+	}
+
+	FGameplayTagContainer ActiveTags = AbilityComponent->GetActiveTags();
+	
+	for (auto& Mapping : PropertyMappings)
+	{
+		FProperty *Property = Mapping.PropertyToMap.Get();
+		if (Mapping.TagsToMap.IsValid() && Property)
+		{
+			FGameplayTagContainer Matched = ActiveTags.Filter(Mapping.TagsToMap);
+			SetValueForMappedProperty(Property, Matched);
+		}
+	}
+}
+
+void FGMCGameplayElementTagPropertyMap::Unregister()
+{
+	if (UGMC_AbilitySystemComponent* AbilityComponent = CachedAbilityComponent.Get())
+	{
+		for (auto& Mapping : PropertyMappings)
+		{
+			if (Mapping.PropertyToMap.Get() && Mapping.DelegateHandle.IsValid())
+			{
+				AbilityComponent->RemoveFilteredTagChangeDelegate(Mapping.TagsToMap, Mapping.DelegateHandle);
+			}
+			Mapping.PropertyToMap = nullptr;
+			Mapping.DelegateHandle.Reset();
+		}
+	}
+
+	CachedOwner = nullptr;
+	CachedAbilityComponent = nullptr;
+}
+
+void FGMCGameplayElementTagPropertyMap::GameplayTagChangedCallback(const FGameplayTagContainer& AddedTags,
+	const FGameplayTagContainer& RemovedTags)
+{
+	UObject* Owner = CachedOwner.Get();
+	const UGMC_AbilitySystemComponent* AbilityComponent = CachedAbilityComponent.Get();
+
+	if (!Owner || !AbilityComponent)
+	{
+		UE_LOG(LogGMCAbilitySystem, Warning, TEXT("FGMCGameplayElementTagPropertyMap: Received callback on uninitialized map!"));
+		return;
+	}
+
+	for (auto& Mapping : PropertyMappings)
+	{
+		const bool bMatched = AddedTags.HasAny(Mapping.TagsToMap) || RemovedTags.HasAny(Mapping.TagsToMap);
+
+		if (bMatched && Mapping.PropertyToMap.Get())
+		{
+			FGameplayTagContainer Matched = AbilityComponent->GetActiveTags().Filter(Mapping.TagsToMap);
+			SetValueForMappedProperty(Mapping.PropertyToMap.Get(), Matched);
+		}
+	}
+}
+
+bool FGMCGameplayElementTagPropertyMap::IsPropertyTypeValid(const FProperty* Property) const
+{
+	check(Property);
+	return (Property->IsA<FBoolProperty>() || Property->IsA<FIntProperty>() || Property->IsA<FFloatProperty>() || Property->IsA<FDoubleProperty>());
+}

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/WaitForGameplayTagChange.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/WaitForGameplayTagChange.h
@@ -30,11 +30,11 @@ public:
 	EGMCWaitForGameplayTagChangeType ChangeType;
 	
 	UFUNCTION(BlueprintCallable, meta=(BlueprintInternalUseOnly="true", HidePin="OwningAbility", DefaultToSelf="OwningAbility", DisplayName="Wait for Gameplay Tag Change"), Category="GMCAbilitySystem|Tasks")
-	static UGMCAbilityTask_WaitForGameplayTagChange* WaitForGameplayTagChange(UGMCAbility* OwningAbility, FGameplayTagContainer WatchedTags, EGMCWaitForGameplayTagChangeType ChangeType = Changed);
+	static UGMCAbilityTask_WaitForGameplayTagChange* WaitForGameplayTagChange(UGMCAbility* OwningAbility, const FGameplayTagContainer& WatchedTags, EGMCWaitForGameplayTagChangeType ChangeType = Changed);
 	
 	virtual void Activate() override;
 
-	virtual void OnGameplayTagChanged(FGameplayTagContainer AddedTags, FGameplayTagContainer RemovedTags);
+	virtual void OnGameplayTagChanged(const FGameplayTagContainer& AddedTags, const FGameplayTagContainer& RemovedTags);
 	
 private:
 

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/WaitForGameplayTagChange.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/WaitForGameplayTagChange.h
@@ -1,0 +1,43 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "GMCAbilityTaskBase.h"
+#include "WaitForGameplayTagChange.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FGMCAbilityTaskWaitForGameplayTagChangeAsyncActionPin, FGameplayTagContainer, MatchedTags);
+
+UENUM()
+enum EGMCWaitForGameplayTagChangeType : uint8
+{
+	Set UMETA(Tooltip="A matching gameplay tag must be present."),
+	Unset UMETA(Tooltip="A matching gameplay tag CANNOT be present."),
+	Changed UMETA(Tooltip="A matching gameplay tag must change state.")
+};
+
+/**
+ * Wait for a change in active gameplay tags matching a provided filter.
+ */
+UCLASS()
+class GMCABILITYSYSTEM_API UGMCAbilityTask_WaitForGameplayTagChange : public UGMCAbilityTaskBase
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(BlueprintAssignable)
+	FGMCAbilityTaskWaitForGameplayTagChangeAsyncActionPin Completed;
+
+	FGameplayTagContainer Tags;
+	EGMCWaitForGameplayTagChangeType ChangeType;
+	
+	UFUNCTION(BlueprintCallable, meta=(BlueprintInternalUseOnly="true", HidePin="OwningAbility", DefaultToSelf="OwningAbility", DisplayName="Wait for Gameplay Tag Change"), Category="GMCAbilitySystem|Tasks")
+	static UGMCAbilityTask_WaitForGameplayTagChange* WaitForGameplayTagChange(UGMCAbility* OwningAbility, FGameplayTagContainer WatchedTags, EGMCWaitForGameplayTagChangeType ChangeType = Changed);
+	
+	virtual void Activate() override;
+
+	virtual void OnGameplayTagChanged(FGameplayTagContainer AddedTags, FGameplayTagContainer RemovedTags);
+	
+private:
+
+	FDelegateHandle ChangeDelegate;
+	
+};

--- a/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
+++ b/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
@@ -1,0 +1,31 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Animation/AnimInstance.h"
+#include "Utility/GameplayElementMapping.h"
+#include "GMCAbilityAnimInstance.generated.h"
+
+class UGMC_AbilitySystemComponent;
+/**
+ * An animation blueprint with built-in support for the GMC Ability System. A property will automatically be
+ * set to the owner's ability system (if present), and a "Tag Property Map" allows any valid gameplay tag to be
+ * mapped automatically to properties.
+ */
+UCLASS()
+class GMCABILITYSYSTEM_API UGMCAbilityAnimInstance : public UAnimInstance
+{
+	GENERATED_BODY()
+
+public:
+	virtual void NativeInitializeAnimation() override;
+
+	UGMC_AbilitySystemComponent* GetAbilitySystemComponent() const { return AbilitySystemComponent; }
+	
+protected:
+
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category="Ability System")
+	UGMC_AbilitySystemComponent* AbilitySystemComponent;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Ability System")
+	FGMCGameplayElementTagPropertyMap TagPropertyMap;
+};

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -23,7 +23,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FOnAttributeChanged, FGameplayTag
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnAncillaryTick, float, DeltaTime);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnActiveTagsChanged, FGameplayTagContainer, AddedTags, FGameplayTagContainer, RemovedTags);
-DECLARE_MULTICAST_DELEGATE_TwoParams(FGameplayTagFilteredMulticastDelegate, FGameplayTagContainer, FGameplayTagContainer);
+DECLARE_MULTICAST_DELEGATE_TwoParams(FGameplayTagFilteredMulticastDelegate, const FGameplayTagContainer&, const FGameplayTagContainer&);
 
 USTRUCT()
 struct FEffectStatePrediction

--- a/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
+++ b/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
@@ -1,0 +1,87 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
+#include "GMCAbilityComponent.h"
+#include "UObject/Object.h"
+#include "GameplayElementMapping.generated.h"
+
+class UGMC_AbilitySystemComponent;
+/**
+ * Struct used to store an individual mapping between a gameplay tag relevant in some way to GMC and
+ * a Blueprint property field. Functionally GMAS' equivalent to GAS's FGameplayTagBlueprintPropertyMap.
+ */
+USTRUCT()
+struct GMCABILITYSYSTEM_API FGMCGameplayElementTagPropertyMapping
+{
+
+	GENERATED_BODY()
+
+	FGMCGameplayElementTagPropertyMapping() {}
+	FGMCGameplayElementTagPropertyMapping(const FGMCGameplayElementTagPropertyMapping& Other)
+	{
+		TagsToMap = Other.TagsToMap;
+		PropertyToMap = Other.PropertyToMap;
+		PropertyName = Other.PropertyName;
+		PropertyGuid = Other.PropertyGuid;
+	}
+	
+	UPROPERTY(EditAnywhere)
+	FGameplayTagContainer TagsToMap;
+
+	UPROPERTY(VisibleAnywhere)
+	TFieldPath<FProperty> PropertyToMap;	
+
+	UPROPERTY(VisibleAnywhere)
+	FName PropertyName;
+
+	UPROPERTY(VisibleAnywhere)
+	FGuid PropertyGuid;
+
+	FDelegateHandle DelegateHandle;
+	
+};
+
+
+/**
+ * Struct containing a collection of individual tag/property mappings. Functionally the
+ * GMAS equivalent to GAS' FGameplayTagBlueprintPropertyMap collection.
+ */
+USTRUCT(BlueprintType)
+struct GMCABILITYSYSTEM_API FGMCGameplayElementTagPropertyMap
+{
+	GENERATED_BODY()
+
+public:
+
+	FGMCGameplayElementTagPropertyMap();
+	FGMCGameplayElementTagPropertyMap(const FGMCGameplayElementTagPropertyMap& Other);
+	~FGMCGameplayElementTagPropertyMap();
+
+	// Must be called to actually start using this instance.
+	void Initialize(UObject* Owner, UGMC_AbilitySystemComponent* AbilitySystemComponent);
+
+	void ApplyCurrentTags();
+
+#if WITH_EDITOR
+	EDataValidationResult IsDataValid(const UObject* ContainingAsset, FDataValidationContext& Context) const;
+#endif
+	
+
+protected:
+
+	bool SetValueForMappedProperty(FProperty* Property, FGameplayTagContainer& MatchedTags);
+	
+	void Unregister();
+
+	void GameplayTagChangedCallback(const FGameplayTagContainer& AddedTags, const FGameplayTagContainer& RemovedTags);
+
+	bool IsPropertyTypeValid(const FProperty* Property) const;
+	
+	TWeakObjectPtr<UObject> CachedOwner;
+	TWeakObjectPtr<UGMC_AbilitySystemComponent> CachedAbilityComponent;
+
+	UPROPERTY(EditAnywhere)
+	TArray<FGMCGameplayElementTagPropertyMapping> PropertyMappings;
+	
+};

--- a/Source/GMCAbilitySystemEditor/GMCAbilitySystemEditor.Build.cs
+++ b/Source/GMCAbilitySystemEditor/GMCAbilitySystemEditor.Build.cs
@@ -1,0 +1,29 @@
+﻿using UnrealBuildTool;
+
+public class GMCAbilitySystemEditor : ModuleRules
+{
+    public GMCAbilitySystemEditor(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "Core",
+                "GMCAbilitySystem",
+                "PropertyEditor"
+            }
+        );
+
+        PrivateDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "CoreUObject",
+                "Engine",
+                "Slate",
+                "SlateCore",
+                "InputCore"
+            }
+        );
+    }
+}

--- a/Source/GMCAbilitySystemEditor/Private/GMCAbilitySystemEditor.cpp
+++ b/Source/GMCAbilitySystemEditor/Private/GMCAbilitySystemEditor.cpp
@@ -1,0 +1,24 @@
+﻿#include "GMCAbilitySystemEditor.h"
+#include "Properties/GameplayElementMappingDetails.h"
+
+#define LOCTEXT_NAMESPACE "FGMCAbilitySystemEditorModule"
+
+void FGMCAbilitySystemEditorModule::StartupModule()
+{
+	FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
+	PropertyModule.RegisterCustomPropertyTypeLayout( "GMCGameplayElementTagPropertyMapping", FOnGetPropertyTypeCustomizationInstance::CreateStatic( &FGMCGameplayElementTagPropertyMappingPropertyDetails::MakeInstance ) );
+    
+}
+
+void FGMCAbilitySystemEditorModule::ShutdownModule()
+{
+	if (FModuleManager::Get().IsModuleLoaded("PropertyEditor"))
+	{
+		FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
+		PropertyModule.UnregisterCustomPropertyTypeLayout("GMCGameplayElementTagPropertyMapping");
+	}
+}
+
+#undef LOCTEXT_NAMESPACE
+    
+IMPLEMENT_MODULE(FGMCAbilitySystemEditorModule, GMCAbilitySystemEditor)

--- a/Source/GMCAbilitySystemEditor/Private/Properties/GameplayElementMappingDetails.cpp
+++ b/Source/GMCAbilitySystemEditor/Private/Properties/GameplayElementMappingDetails.cpp
@@ -1,0 +1,188 @@
+﻿#include "Properties/GameplayElementMappingDetails.h"
+#include "Utility/GameplayElementMapping.h"
+#include "PropertyHandle.h"
+#include "DetailWidgetRow.h"
+#include "IDetailChildrenBuilder.h"
+#include "IDetailPropertyRow.h"
+#include "Engine/Blueprint.h"
+#include "Widgets/Input/SComboBox.h"
+
+TSharedRef<IPropertyTypeCustomization> FGMCGameplayElementTagPropertyMappingPropertyDetails::MakeInstance()
+{
+	return MakeShareable(new FGMCGameplayElementTagPropertyMappingPropertyDetails());
+}
+
+void FGMCGameplayElementTagPropertyMappingPropertyDetails::CustomizeHeader(TSharedRef<IPropertyHandle> StructPropertyHandle,
+	FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& CustomizationUtils)
+{
+	NamePropertyHandle = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FGMCGameplayElementTagPropertyMapping, PropertyName));
+	GuidPropertyHandle = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FGMCGameplayElementTagPropertyMapping, PropertyGuid));
+
+	FString SelectedPropertyName;
+	NamePropertyHandle->GetValue(SelectedPropertyName);
+
+	TArray<void*> RawData;
+	GuidPropertyHandle->AccessRawData(RawData);
+
+	FGuid SelectedPropertyGuid;
+	if (RawData.Num() > 0)
+	{
+		SelectedPropertyGuid = *static_cast<FGuid*>(RawData[0]);
+	}
+
+	FProperty* FoundProperty = nullptr;
+
+	TArray<UObject*> OuterObjects;
+	NamePropertyHandle->GetOuterObjects(OuterObjects);
+
+	for (UObject* ParentObject : OuterObjects)
+	{
+		if (!ParentObject)
+		{
+			continue;
+		}
+
+		for (TFieldIterator<FProperty> PropertyIt(ParentObject->GetClass()); PropertyIt; ++PropertyIt)
+		{
+			FProperty* Property = *PropertyIt;
+			if (!Property)
+			{
+				continue;
+			}
+
+			// Only support booleans, floats, and integers.
+			const bool bIsValidType = Property->IsA(FBoolProperty::StaticClass()) || Property->IsA(FIntProperty::StaticClass()) || Property->IsA(FFloatProperty::StaticClass());
+			if (!bIsValidType)
+			{
+				continue;
+			}
+
+			// Only accept properties from a blueprint.
+			if (!UBlueprint::GetBlueprintFromClass(Property->GetOwnerClass()))
+			{
+				continue;
+			}
+
+			// Ignore properties that don't have a GUID since we rely on it to handle property name changes.
+			FGuid PropertyToTestGuid = GetPropertyGuid(Property);
+			if (!PropertyToTestGuid.IsValid())
+			{
+				continue;
+			}
+
+			// Add the property to the combo box.
+			PropertyOptions.AddUnique(Property);
+
+			// Find our current selected property in the list.
+			if (SelectedPropertyGuid == PropertyToTestGuid)
+			{
+				FoundProperty = Property;
+			}
+		}
+	}
+
+	// Sort the options list alphabetically.
+	PropertyOptions.StableSort([](const TFieldPath<FProperty>& A, const TFieldPath<FProperty>& B) { return (A->GetName() < B->GetName()); });
+
+	if ((FoundProperty == nullptr) || (FoundProperty != SelectedProperty) || (FoundProperty->GetName() != SelectedPropertyName))
+	{
+		// The selected property needs to be updated.
+		OnChangeProperty(FoundProperty, ESelectInfo::Direct);
+	}
+
+	HeaderRow
+		.NameContent()
+		[
+			StructPropertyHandle->CreatePropertyNameWidget()
+		];	
+}	
+
+void FGMCGameplayElementTagPropertyMappingPropertyDetails::CustomizeChildren(TSharedRef<IPropertyHandle> StructPropertyHandle,
+	IDetailChildrenBuilder& ChildBuilder, IPropertyTypeCustomizationUtils& CustomizationUtils)
+{
+	TSharedPtr<IPropertyHandle> TagsToMapHandle = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FGMCGameplayElementTagPropertyMapping, TagsToMap));
+	TSharedPtr<IPropertyHandle> PropertyToEditHandle = StructPropertyHandle->GetChildHandle(GET_MEMBER_NAME_CHECKED(FGMCGameplayElementTagPropertyMapping, PropertyToMap));
+
+	// Add the FGameplay Tag first.
+	ChildBuilder.AddProperty(TagsToMapHandle.ToSharedRef());
+
+	// Add the combo box next.
+	IDetailPropertyRow& PropertyRow = ChildBuilder.AddProperty(StructPropertyHandle);
+	PropertyRow.CustomWidget()
+		.NameContent()
+		[
+			PropertyToEditHandle->CreatePropertyNameWidget()
+		]
+
+		.ValueContent()
+		.HAlign(HAlign_Left)
+		.MinDesiredWidth(250.0f)
+		[
+			SNew(SHorizontalBox)
+			+SHorizontalBox::Slot()
+			.HAlign(HAlign_Fill)
+			.Padding(0.0f, 0.0f, 2.0f, 0.0f)
+			[
+				SNew(SComboBox< TFieldPath<FProperty> >)
+				.OptionsSource(&PropertyOptions)
+				.OnGenerateWidget(this, &FGMCGameplayElementTagPropertyMappingPropertyDetails::GeneratePropertyWidget)
+				.OnSelectionChanged(this, &FGMCGameplayElementTagPropertyMappingPropertyDetails::OnChangeProperty)
+				.ContentPadding(FMargin(2.0f, 2.0f))
+				.ToolTipText(this, &FGMCGameplayElementTagPropertyMappingPropertyDetails::GetSelectedValueText)
+				.InitiallySelectedItem(SelectedProperty)
+				[
+					SNew(STextBlock)
+					.Text(this, &FGMCGameplayElementTagPropertyMappingPropertyDetails::GetSelectedValueText)
+				]
+			]
+		];	
+}
+
+void FGMCGameplayElementTagPropertyMappingPropertyDetails::OnChangeProperty(TFieldPath<FProperty> ItemSelected,
+	ESelectInfo::Type SelectInfo)
+{
+	if (NamePropertyHandle.IsValid() && GuidPropertyHandle.IsValid())
+	{
+		SelectedProperty = ItemSelected;
+
+		NamePropertyHandle->SetValue(GetPropertyName(ItemSelected));
+
+		TArray<void*> RawData;
+		GuidPropertyHandle->AccessRawData(RawData);
+
+		if (RawData.Num() > 0)
+		{
+			FGuid* RawGuid = static_cast<FGuid*>(RawData[0]);
+			*RawGuid = GetPropertyGuid(ItemSelected);
+		}
+	}
+}
+
+FGuid FGMCGameplayElementTagPropertyMappingPropertyDetails::GetPropertyGuid(TFieldPath<FProperty> Property) const
+{
+	FGuid Guid;
+
+	if (Property != nullptr)
+	{
+		UBlueprint::GetGuidFromClassByFieldName<FProperty>(Property->GetOwnerClass(), Property->GetFName(), Guid);
+	}
+
+	return Guid;
+}
+
+FString FGMCGameplayElementTagPropertyMappingPropertyDetails::GetPropertyName(TFieldPath<FProperty> Property) const
+{
+	return (Property != nullptr ? Property->GetName() : TEXT("None"));
+}
+
+TSharedRef<SWidget> FGMCGameplayElementTagPropertyMappingPropertyDetails::GeneratePropertyWidget(
+	TFieldPath<FProperty> Property)
+{
+	return SNew(STextBlock).Text(FText::FromString(GetPropertyName(Property.Get())));
+}
+
+FText FGMCGameplayElementTagPropertyMappingPropertyDetails::GetSelectedValueText() const
+{
+	return FText::FromString(GetPropertyName(SelectedProperty));
+}
+

--- a/Source/GMCAbilitySystemEditor/Public/GMCAbilitySystemEditor.h
+++ b/Source/GMCAbilitySystemEditor/Public/GMCAbilitySystemEditor.h
@@ -1,0 +1,11 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+
+class FGMCAbilitySystemEditorModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+};

--- a/Source/GMCAbilitySystemEditor/Public/Properties/GameplayElementMappingDetails.h
+++ b/Source/GMCAbilitySystemEditor/Public/Properties/GameplayElementMappingDetails.h
@@ -1,0 +1,37 @@
+﻿#pragma once
+
+#include "UObject/FieldPath.h"
+#include "IPropertyTypeCustomization.h"
+
+class IPropertyHandle;
+class FDetailWidgetRow;
+class IDetailChildrenBuilder;
+class SWidget;
+
+class FGMCGameplayElementTagPropertyMappingPropertyDetails : public IPropertyTypeCustomization
+{
+public:
+
+	static TSharedRef<IPropertyTypeCustomization> MakeInstance();
+
+	virtual void CustomizeHeader(TSharedRef<IPropertyHandle> StructPropertyHandle, FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& CustomizationUtils) override;
+	virtual void CustomizeChildren(TSharedRef<IPropertyHandle> StructPropertyHandle, IDetailChildrenBuilder& ChildBuilder, IPropertyTypeCustomizationUtils& CustomizationUtils) override;
+
+protected:
+
+	void OnChangeProperty(TFieldPath<FProperty> ItemSelected, ESelectInfo::Type SelectInfo);
+
+	FGuid GetPropertyGuid(TFieldPath<FProperty> Property) const;
+	FString GetPropertyName(TFieldPath<FProperty> Property) const;
+
+	TSharedRef<SWidget> GeneratePropertyWidget(TFieldPath<FProperty> Property);
+
+	FText GetSelectedValueText() const;
+
+	TSharedPtr<IPropertyHandle> NamePropertyHandle;
+	TSharedPtr<IPropertyHandle> GuidPropertyHandle;
+
+	TArray<TFieldPath<FProperty>> PropertyOptions;
+
+	TFieldPath<FProperty> SelectedProperty;	
+};


### PR DESCRIPTION
This is an actual feature addition, separate from the cleanup PR, and adds several things:

* An `OnActiveTagsChanged` delegate, called when the active tags change at all.
* The ability to add targeted delegates, which will only be called when changes to tags match a specific filter.
* A `WaitForGameplayTagChange` ability task, powered by the above.

The second of those is also necessary to (properly) create a GMCAbilitySystem equivalent to GAS's ability to map tag filters to blueprint properties and have them automatically updated, which is kinda useful in general and _very_ useful in animation blueprints specifically.