### PR TITLE
Add the ability to map attributes to properties as well as tags.

### DIFF
--- a/GMCAbilitySystem.uplugin
+++ b/GMCAbilitySystem.uplugin
@@ -4,7 +4,7 @@
 	"VersionName": "1.0",
 	"FriendlyName": "GMCAbilitySystem",
 	"Description": "",
-	"Category": "Other",
+	"Category": "GMC",
 	"CreatedBy": "Reznok",
 	"CreatedByURL": "",
 	"DocsURL": "",

--- a/Source/GMCAbilitySystem/Private/Animation/GMCAbilityAnimInstance.cpp
+++ b/Source/GMCAbilitySystem/Private/Animation/GMCAbilityAnimInstance.cpp
@@ -1,17 +1,33 @@
 ﻿#include "Animation/GMCAbilityAnimInstance.h"
+#include "GMCPawn.h"
 #include "GMCAbilityComponent.h"
 
 void UGMCAbilityAnimInstance::NativeInitializeAnimation()
 {
-	if (const AActor* OwnerActor = GetOwningActor())
+	// A subclass may have already set these before calling us, so check if we need to do the work.
+	if (!AbilitySystemComponent || !GMCPawn)
 	{
-		AbilitySystemComponent = Cast<UGMC_AbilitySystemComponent>(OwnerActor->GetComponentByClass(UGMC_AbilitySystemComponent::StaticClass()));
-		if (AbilitySystemComponent)
+		AActor* OwnerActor = GetOwningActor();
+		if (OwnerActor)
 		{
-			TagPropertyMap.Initialize(this, AbilitySystemComponent);
+			GMCPawn = Cast<AGMC_Pawn>(OwnerActor);
+			AbilitySystemComponent = Cast<UGMC_AbilitySystemComponent>(OwnerActor->GetComponentByClass(UGMC_AbilitySystemComponent::StaticClass()));
 		}
+		
+#if WITH_EDITOR
+		if (!GetWorld()->IsGameWorld() && !IsValid(AbilitySystemComponent) && GMCPawn)
+		{
+			// Create a default for in-editor preview.
+			AbilitySystemComponent = GMCPawn->CreateDefaultSubobject<UGMC_AbilitySystemComponent>(TEXT("AbilityComponent"));
+		}
+#endif
 	}
 
+	if (AbilitySystemComponent)
+	{
+		TagPropertyMap.Initialize(this, AbilitySystemComponent);
+	}
+	
 	// As the super call will trigger the blueprint initialize event, we want to do it *after* we've set our
 	// Ability System Component.
 	Super::NativeInitializeAnimation();

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -61,6 +61,17 @@ void UGMC_AbilitySystemComponent::RemoveFilteredTagChangeDelegate(const FGamepla
 	}
 }
 
+FDelegateHandle UGMC_AbilitySystemComponent::AddAttributeChangeDelegate(
+	const FGameplayAttributeChangedNative::FDelegate& Delegate)
+{
+	return NativeAttributeChangeDelegate.Add(Delegate);
+}
+
+void UGMC_AbilitySystemComponent::RemoveAttributeChangeDelegate(FDelegateHandle Handle)
+{
+	NativeAttributeChangeDelegate.Remove(Handle);
+}
+
 void UGMC_AbilitySystemComponent::BindReplicationData()
 {
 	// Attribute Binds
@@ -649,6 +660,7 @@ void UGMC_AbilitySystemComponent::OnRep_UnBoundAttributes(FInstancedStruct Previ
 	for (const FAttribute& Attribute : CurrentAttributes){
 		if (OldValues.Contains(Attribute.Tag) && OldValues[Attribute.Tag] != Attribute.Value){
 			OnAttributeChanged.Broadcast(Attribute.Tag, OldValues[Attribute.Tag], Attribute.Value);
+			NativeAttributeChangeDelegate.Broadcast(Attribute.Tag, OldValues[Attribute.Tag], Attribute.Value);
 		}
 	}
 }
@@ -878,6 +890,7 @@ void UGMC_AbilitySystemComponent::ApplyAbilityEffectModifier(FGMCAttributeModifi
 		AffectedAttribute->ApplyModifier(AttributeModifier);
 
 		OnAttributeChanged.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
+		NativeAttributeChangeDelegate.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
 	}
 }
 

--- a/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
+++ b/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
@@ -24,6 +24,9 @@ public:
 protected:
 
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category="Ability System")
+	AGMC_Pawn* GMCPawn;
+	
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category="Ability System")
 	UGMC_AbilitySystemComponent* AbilitySystemComponent;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Ability System")

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -19,6 +19,7 @@ class UGMCAttributesData;
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnPreAttributeChanged, UGMCAttributeModifierContainer*, AttributeModifierContainer, UGMC_AbilitySystemComponent*,
                                              SourceAbilityComponent);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FOnAttributeChanged, FGameplayTag, AttributeTag, float, OldValue, float, NewValue);
+DECLARE_MULTICAST_DELEGATE_ThreeParams(FGameplayAttributeChangedNative, const FGameplayTag&, const float, const float);
 				
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnAncillaryTick, float, DeltaTime);
 
@@ -241,6 +242,19 @@ public:
 	 */
 	void RemoveFilteredTagChangeDelegate(const FGameplayTagContainer& Tags, FDelegateHandle Handle);
 
+	/**
+	 * Adds a native (e.g. suitable for use in structs) delegate binding for attribute changes.
+	 * @param Delegate The delegate to call on attribute changes.
+	 * @return A handle to use when removing this delegate.
+	 */
+	FDelegateHandle AddAttributeChangeDelegate(const FGameplayAttributeChangedNative::FDelegate& Delegate);
+
+	/**
+	 * Removes a native (e.g. suitable for use in structs) delegate for attribute changes.
+	 * @param Handle The delegate handle to be removed.
+	 */
+	void RemoveAttributeChangeDelegate(FDelegateHandle Handle);
+
 #pragma region GMC
 	// GMC
 	UFUNCTION(BlueprintCallable, Category="GMCAbilitySystem")
@@ -329,6 +343,8 @@ private:
 
 	// List of filtered tag delegates to call when tags change.
 	TArray<TPair<FGameplayTagContainer, FGameplayTagFilteredMulticastDelegate>> FilteredTagDelegates;
+
+	FGameplayAttributeChangedNative NativeAttributeChangeDelegate;
 	
 	// Get the map from the data asset and apply that to the component's map
 	void InitializeAbilityMap();

--- a/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
+++ b/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
@@ -62,6 +62,7 @@ public:
 	void Initialize(UObject* Owner, UGMC_AbilitySystemComponent* AbilitySystemComponent);
 
 	void ApplyCurrentTags();
+	void ApplyCurrentAttributes();
 
 #if WITH_EDITOR
 	EDataValidationResult IsDataValid(const UObject* ContainingAsset, FDataValidationContext& Context) const;
@@ -70,13 +71,18 @@ public:
 
 protected:
 
+	bool SetValueForMappedProperty(FProperty* Property, float PropValue);
 	bool SetValueForMappedProperty(FProperty* Property, FGameplayTagContainer& MatchedTags);
 	
 	void Unregister();
 
 	void GameplayTagChangedCallback(const FGameplayTagContainer& AddedTags, const FGameplayTagContainer& RemovedTags);
 
+	void GameplayAttributeChangedCallback(const FGameplayTag& AttributeTag, const float OldValue, const float NewValue);
+
 	bool IsPropertyTypeValid(const FProperty* Property) const;
+
+	FDelegateHandle AttributeHandle;
 	
 	TWeakObjectPtr<UObject> CachedOwner;
 	TWeakObjectPtr<UGMC_AbilitySystemComponent> CachedAbilityComponent;


### PR DESCRIPTION
If a property binding has a single tag (rather than multiple), it will also be considered valid for any attribute changes which match that tag.

* Boolean properties will be set as (value > 0)
* Int properties will be set as the rounded attribute value.
* Float and Double properties will be set as the attribute value.

Also changes the plugin category to "GMC", where GMCExtended is going to live as well, so that extension plugins get grouped together nicely in the plugin manager. :)