### PR TITLE
Guard against uninitialized attributes.

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -763,11 +763,26 @@ int32 UGMC_AbilitySystemComponent::GetNumEffectByTag(FGameplayTag InEffectTag){
 
 TArray<const FAttribute*> UGMC_AbilitySystemComponent::GetAllAttributes() const{
 	TArray<const FAttribute*> AllAttributes;
-	for (const FAttribute& Attribute : UnBoundAttributes.Get<FGMCAttributeSet>().Attributes){
-		AllAttributes.Add(&Attribute);
+	if (UnBoundAttributes.IsValid())
+	{
+		for (const FAttribute& Attribute : UnBoundAttributes.Get<FGMCAttributeSet>().Attributes){
+			AllAttributes.Add(&Attribute);
+		}
 	}
-	for (const FAttribute& Attribute : BoundAttributes.Get<FGMCAttributeSet>().Attributes){
-		AllAttributes.Add(&Attribute);
+	else
+	{
+		UE_LOG(LogGMCAbilitySystem, Warning, TEXT("UGMC_AbilitySystemComponent: %s (%s) is missing unbound attributes!"), *(GetOwner()->GetName()), *(GetOwner()->GetClass()->GetName()));
+	}
+
+	if (BoundAttributes.IsValid())
+	{
+		for (const FAttribute& Attribute : BoundAttributes.Get<FGMCAttributeSet>().Attributes){
+			AllAttributes.Add(&Attribute);
+		}
+	}
+	else
+	{
+		UE_LOG(LogGMCAbilitySystem, Warning, TEXT("UGMC_AbilitySystemComponent: %s (%s) is missing bound attributes!"), *(GetOwner()->GetName()), *(GetOwner()->GetClass()->GetName()));
 	}
 	return AllAttributes;
 }

--- a/Source/GMCAbilitySystem/Private/Utility/GameplayElementMapping.cpp
+++ b/Source/GMCAbilitySystem/Private/Utility/GameplayElementMapping.cpp
@@ -63,25 +63,25 @@ bool FGMCGameplayElementTagPropertyMap::SetValueForMappedProperty(FProperty* Pro
 {
 	UObject* Owner = CachedOwner.Get();
 
-	if (const FBoolProperty* BoolProperty = Cast<FBoolProperty>(Property))
+	if (const FBoolProperty* BoolProperty = static_cast<FBoolProperty*>(Property))
 	{
 		BoolProperty->SetPropertyValue_InContainer(Owner, Value > 0.f);
 		return true;
 	}
 
-	if (const FIntProperty* IntProperty = Cast<FIntProperty>(Property))
+	if (const FIntProperty* IntProperty = static_cast<FIntProperty*>(Property))
 	{
 		IntProperty->SetPropertyValue_InContainer(Owner, FMath::RoundToInt(Value));
 		return true;
 	}
 
-	if (const FFloatProperty* FloatProperty = Cast<FFloatProperty>(Property))
+	if (const FFloatProperty* FloatProperty = static_cast<FFloatProperty*>(Property))
 	{
 		FloatProperty->SetPropertyValue_InContainer(Owner, Value);
 		return true;
 	}
 
-	if (const FDoubleProperty* DoubleProperty = Cast<FDoubleProperty>(Property))
+	if (const FDoubleProperty* DoubleProperty = static_cast<FDoubleProperty*>(Property))
 	{
 		DoubleProperty->SetPropertyValue_InContainer(Owner, Value);
 		return true;

--- a/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
+++ b/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
@@ -17,6 +17,7 @@ class GMCABILITYSYSTEM_API UGMCAbilityAnimInstance : public UAnimInstance
 	GENERATED_BODY()
 
 public:
+	virtual void NativeBeginPlay() override;
 	virtual void NativeInitializeAnimation() override;
 
 	UGMC_AbilitySystemComponent* GetAbilitySystemComponent() const { return AbilitySystemComponent; }


### PR DESCRIPTION
This addresses #38 -- I had fixed it in my game-specific fork of GMAS a while ago, and forgot to merge it over to normal dev.