### PR TITLE
Minor cleanup/safety checks.

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -100,7 +100,7 @@ void UGMC_AbilitySystemComponent::BindReplicationData()
 		EGMC_InterpolationFunction::TargetValue);
 
 	// Attributes
-	BindInstancedStruct(BoundAttributes,
+	GMCMovementComponent->BindInstancedStruct(BoundAttributes,
 		EGMC_PredictionMode::ServerAuth_Output_ClientValidated,
 		EGMC_CombineMode::CombineIfUnchanged,
 		EGMC_SimulationMode::Periodic_Output,
@@ -121,7 +121,7 @@ void UGMC_AbilitySystemComponent::BindReplicationData()
 		EGMC_InterpolationFunction::TargetValue);
 	
 	// TaskData Bind
-	BindInstancedStruct(TaskData,
+	GMCMovementComponent->BindInstancedStruct(TaskData,
 		EGMC_PredictionMode::ClientAuth_Input,
 		EGMC_CombineMode::CombineIfUnchanged,
 		EGMC_SimulationMode::None,

--- a/Source/GMCAbilitySystem/Private/Debug/GameplayDebuggerCategory_GMCAbilitySystem.cpp
+++ b/Source/GMCAbilitySystem/Private/Debug/GameplayDebuggerCategory_GMCAbilitySystem.cpp
@@ -17,16 +17,23 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::CollectData(APlayerController* 
 {
 	if (OwnerPC)
 	{
-		DataPack.ActorName = OwnerPC->GetPawn()->GetName();
-
-		if (const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>())
+		if (OwnerPC->GetPawn())
 		{
-			DataPack.GrantedAbilities = AbilityComponent->GetGrantedAbilities().ToStringSimple();
-			DataPack.ActiveTags = AbilityComponent->GetActiveTags().ToStringSimple();
-			DataPack.Attributes = AbilityComponent->GetAllAttributesString();
-			DataPack.ActiveEffects = AbilityComponent->GetActiveEffectsString();
-			DataPack.ActiveEffectData = AbilityComponent->GetActiveEffectsDataString();
-			DataPack.ActiveAbilities = AbilityComponent->GetActiveAbilitiesString();
+			DataPack.ActorName = OwnerPC->GetPawn()->GetName();
+
+			if (const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>())
+			{
+				DataPack.GrantedAbilities = AbilityComponent->GetGrantedAbilities().ToStringSimple();
+				DataPack.ActiveTags = AbilityComponent->GetActiveTags().ToStringSimple();
+				DataPack.Attributes = AbilityComponent->GetAllAttributesString();
+				DataPack.ActiveEffects = AbilityComponent->GetActiveEffectsString();
+				DataPack.ActiveEffectData = AbilityComponent->GetActiveEffectsDataString();
+				DataPack.ActiveAbilities = AbilityComponent->GetActiveAbilitiesString();
+			}
+		}
+		else
+		{
+			DataPack.ActorName = TEXT("Spectator or missing pawn");
 		}
 	}
 }
@@ -37,7 +44,7 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::DrawData(APlayerController* Own
 	if (!DataPack.ActorName.IsEmpty())
 	{
 		CanvasContext.Printf(TEXT("{yellow}Actor name: {white}%s"), *DataPack.ActorName);
-		const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>();
+		const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn() ? OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>() : nullptr;
 		if (AbilityComponent == nullptr) return;
 
 		// Abilities

--- a/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
+++ b/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "CoreMinimal.h"
+#include "GMCPawn.h"
 #include "Animation/AnimInstance.h"
 #include "Utility/GameplayElementMapping.h"
 #include "GMCAbilityAnimInstance.generated.h"
@@ -24,6 +25,11 @@ public:
 	
 protected:
 
+#if WITH_EDITORONLY_DATA
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Ability System")
+	TSubclassOf<AGMC_Pawn> EditorPreviewClass { AGMC_Pawn::StaticClass() };
+#endif
+	
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category="Ability System")
 	AGMC_Pawn* GMCPawn;
 	

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -312,26 +312,6 @@ protected:
 	FGMCAbilityData AbilityData;
 	FInstancedStruct TaskData = FInstancedStruct::Make(FGMCAbilityTaskData{});;
 
-	// FInstancedStruct GMC Binding
-	UFUNCTION(BlueprintCallable)
-	int32 BindInstancedStruct(
-	  UPARAM(Ref) FInstancedStruct& VariableToBind,
-	  EGMC_PredictionMode PredictionMode,
-	  EGMC_CombineMode CombineMode,
-	  EGMC_SimulationMode SimulationMode,
-	  EGMC_InterpolationFunction Interpolation
-	)
-	{
-		int32 BindingIndex = -1;
-				GMCMovementComponent->AliasData.InstancedStruct.BindMember(
-				  VariableToBind,
-				  TranslateToSyncSettings(PredictionMode, CombineMode, SimulationMode, Interpolation),
-				  BindingIndex
-				);
-		return BindingIndex;
-	}
-
-
 private:
 
 	// Array of data objects to initialize the component's ability map


### PR DESCRIPTION
Just getting rid of our old no-longer-needed custom binding for structs -- we can just call it in GMC directly -- and adding some error-checking to the debugger category.