### PR TITLE
Add extra accessors for active tags

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -204,7 +204,7 @@ void UGMC_AbilitySystemComponent::RemoveAbilityMapData(UGMCAbilityMapData* Abili
 	}
 }
 
-void UGMC_AbilitySystemComponent::GrantAbilityByTag(FGameplayTag AbilityTag)
+void UGMC_AbilitySystemComponent::GrantAbilityByTag(const FGameplayTag& AbilityTag)
 {
 	if (!GrantedAbilityTags.HasTagExact(AbilityTag))
 	{
@@ -212,7 +212,7 @@ void UGMC_AbilitySystemComponent::GrantAbilityByTag(FGameplayTag AbilityTag)
 	}
 }
 
-void UGMC_AbilitySystemComponent::RemoveGrantedAbilityByTag(FGameplayTag AbilityTag)
+void UGMC_AbilitySystemComponent::RemoveGrantedAbilityByTag(const FGameplayTag& AbilityTag)
 {
 	if (GrantedAbilityTags.HasTagExact(AbilityTag))
 	{
@@ -220,17 +220,17 @@ void UGMC_AbilitySystemComponent::RemoveGrantedAbilityByTag(FGameplayTag Ability
 	}
 }
 
-bool UGMC_AbilitySystemComponent::HasGrantedAbilityTag(FGameplayTag GameplayTag) const
+bool UGMC_AbilitySystemComponent::HasGrantedAbilityTag(const FGameplayTag& GameplayTag) const
 {
 	return GrantedAbilityTags.HasTagExact(GameplayTag);
 }
 
-void UGMC_AbilitySystemComponent::AddActiveTag(FGameplayTag AbilityTag)
+void UGMC_AbilitySystemComponent::AddActiveTag(const FGameplayTag& AbilityTag)
 {
 	ActiveTags.AddTag(AbilityTag);
 }
 
-void UGMC_AbilitySystemComponent::RemoveActiveTag(FGameplayTag AbilityTag)
+void UGMC_AbilitySystemComponent::RemoveActiveTag(const FGameplayTag& AbilityTag)
 {
 	if (ActiveTags.HasTagExact(AbilityTag))
 	{
@@ -238,12 +238,37 @@ void UGMC_AbilitySystemComponent::RemoveActiveTag(FGameplayTag AbilityTag)
 	}
 }
 
-bool UGMC_AbilitySystemComponent::HasActiveTag(FGameplayTag GameplayTag) const
+bool UGMC_AbilitySystemComponent::HasActiveTag(const FGameplayTag& GameplayTag) const
 {
 	return ActiveTags.HasTagExact(GameplayTag);
 }
 
-TArray<FGameplayTag> UGMC_AbilitySystemComponent::GetActiveTagsByParentTag(FGameplayTag ParentTag){
+bool UGMC_AbilitySystemComponent::HasActiveTagExact(const FGameplayTag& GameplayTag) const
+{
+	return ActiveTags.HasTagExact(GameplayTag);
+}
+
+bool UGMC_AbilitySystemComponent::HasAnyTag(const FGameplayTagContainer& TagsToCheck) const
+{
+	return ActiveTags.HasAny(TagsToCheck);
+}
+
+bool UGMC_AbilitySystemComponent::HasAnyTagExact(const FGameplayTagContainer& TagsToCheck) const
+{
+	return ActiveTags.HasAnyExact(TagsToCheck);
+}
+
+bool UGMC_AbilitySystemComponent::HasAllTags(const FGameplayTagContainer& TagsToCheck) const
+{
+	return ActiveTags.HasAll(TagsToCheck);
+}
+
+bool UGMC_AbilitySystemComponent::HasAllTagsExact(const FGameplayTagContainer& TagsToCheck) const
+{
+	return ActiveTags.HasAllExact(TagsToCheck);
+}
+
+TArray<FGameplayTag> UGMC_AbilitySystemComponent::GetActiveTagsByParentTag(const FGameplayTag& ParentTag){
 	TArray<FGameplayTag> MatchedTags;
 	if(!ParentTag.IsValid()) return MatchedTags;
 	for(FGameplayTag Tag : ActiveTags){
@@ -254,7 +279,7 @@ TArray<FGameplayTag> UGMC_AbilitySystemComponent::GetActiveTagsByParentTag(FGame
 	return MatchedTags;
 }
 
-void UGMC_AbilitySystemComponent::TryActivateAbilitiesByInputTag(const FGameplayTag InputTag, const UInputAction* InputAction)
+void UGMC_AbilitySystemComponent::TryActivateAbilitiesByInputTag(const FGameplayTag& InputTag, const UInputAction* InputAction)
 {
 	// UE_LOG(LogTemp, Warning, TEXT("Trying To Activate Ability: %d"), AbilityData.GrantedAbilityIndex);
 	for (const TSubclassOf<UGMCAbility> ActivatedAbility : GetGrantedAbilitiesByTag(InputTag))
@@ -303,7 +328,7 @@ void UGMC_AbilitySystemComponent::QueueTaskData(const FInstancedStruct& InTaskDa
 	QueuedTaskData.Push(InTaskData);
 }
 
-void UGMC_AbilitySystemComponent::SetCooldownForAbility(FGameplayTag AbilityTag, float CooldownTime)
+void UGMC_AbilitySystemComponent::SetCooldownForAbility(const FGameplayTag& AbilityTag, float CooldownTime)
 {
 	if (AbilityTag == FGameplayTag::EmptyTag) return;
 	
@@ -315,7 +340,7 @@ void UGMC_AbilitySystemComponent::SetCooldownForAbility(FGameplayTag AbilityTag,
 	ActiveCooldowns.Add(AbilityTag, CooldownTime);
 }
 
-float UGMC_AbilitySystemComponent::GetCooldownForAbility(FGameplayTag AbilityTag) const
+float UGMC_AbilitySystemComponent::GetCooldownForAbility(const FGameplayTag& AbilityTag) const
 {
 	if (ActiveCooldowns.Contains(AbilityTag))
 	{
@@ -324,7 +349,7 @@ float UGMC_AbilitySystemComponent::GetCooldownForAbility(FGameplayTag AbilityTag
 	return 0.f;
 }
 
-void UGMC_AbilitySystemComponent::MatchTagToBool(FGameplayTag InTag, bool MatchedBool){
+void UGMC_AbilitySystemComponent::MatchTagToBool(const FGameplayTag& InTag, bool MatchedBool){
 	if(!InTag.IsValid()) return;
 	if(MatchedBool){
 		AddActiveTag(InTag);

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -72,32 +72,53 @@ public:
 		
 	// Add an ability to the GrantedAbilities array
 	UFUNCTION(BlueprintCallable)
-	void GrantAbilityByTag(FGameplayTag AbilityTag);
+	void GrantAbilityByTag(const FGameplayTag& AbilityTag);
 
 	// Remove an ability from the GrantedAbilities array
 	UFUNCTION(BlueprintCallable)
-	void RemoveGrantedAbilityByTag(FGameplayTag AbilityTag);
+	void RemoveGrantedAbilityByTag(const FGameplayTag& AbilityTag);
 
 	UFUNCTION(BlueprintPure, meta=(Categories="Ability"))
-	bool HasGrantedAbilityTag(FGameplayTag GameplayTag) const;
+	bool HasGrantedAbilityTag(const FGameplayTag& GameplayTag) const;
 
 	// Add an ability to the GrantedAbilities array
 	UFUNCTION(BlueprintCallable)
-	void AddActiveTag(FGameplayTag AbilityTag);
+	void AddActiveTag(const FGameplayTag& AbilityTag);
 
 	// Remove an ability from the GrantedAbilities array
 	UFUNCTION(BlueprintCallable)
-	void RemoveActiveTag(FGameplayTag AbilityTag);
+	void RemoveActiveTag(const FGameplayTag& AbilityTag);
 
+	// Checks whether any active tag matches this tag or any of its children.
 	UFUNCTION(BlueprintPure)
-	bool HasActiveTag(FGameplayTag GameplayTag) const;
+	bool HasActiveTag(const FGameplayTag& GameplayTag) const;
 
+	// Checks whether any active tag matches this tag exactly; it will not match on child tags.
+	UFUNCTION(BlueprintPure)
+	bool HasActiveTagExact(const FGameplayTag& GameplayTag) const;
+
+	// Checks whether any active tag matches any of the tags provided (or their children).
+	UFUNCTION(BlueprintPure)
+	bool HasAnyTag(const FGameplayTagContainer& TagsToCheck) const;
+
+	// Checks whether any active tag matches any of the tags provided exactly (excluding children).
+	UFUNCTION(BlueprintPure)
+	bool HasAnyTagExact(const FGameplayTagContainer& TagsToCheck) const;
+
+	// Checks whether every tag provided is in current tags, allowing for child tags.
+	UFUNCTION(BlueprintPure)
+	bool HasAllTags(const FGameplayTagContainer& TagsToCheck) const;
+
+	// Checks whether every tag provided is in current tags, without matching on child tags.
+	UFUNCTION(BlueprintPure)
+	bool HasAllTagsExact(const FGameplayTagContainer& TagsToCheck) const;
+	
 	/** Get all active tags that match a given parent tag */
 	UFUNCTION(BlueprintCallable)
-	TArray<FGameplayTag> GetActiveTagsByParentTag(FGameplayTag ParentTag);
+	TArray<FGameplayTag> GetActiveTagsByParentTag(const FGameplayTag& ParentTag);
 
 	// Do not call directly on client, go through QueueAbility
-	void TryActivateAbilitiesByInputTag(FGameplayTag InputTag, const UInputAction* InputAction = nullptr);
+	void TryActivateAbilitiesByInputTag(const FGameplayTag& InputTag, const UInputAction* InputAction = nullptr);
 	
 	// Do not call directly on client, go through QueueAbility. Can be used to call server-side abilities (like AI).
 	bool TryActivateAbility(TSubclassOf<UGMCAbility> ActivatedAbility, const UInputAction* InputAction = nullptr);
@@ -111,17 +132,17 @@ public:
 	// Set an ability cooldown
 	// If it's already on cooldown, subsequent calls will overwrite it
 	UFUNCTION(BlueprintCallable)
-	void SetCooldownForAbility(FGameplayTag AbilityTag, float CooldownTime);
+	void SetCooldownForAbility(const FGameplayTag& AbilityTag, float CooldownTime);
 
 	UFUNCTION(BlueprintPure)
-	float GetCooldownForAbility(FGameplayTag AbilityTag) const;
+	float GetCooldownForAbility(const FGameplayTag& AbilityTag) const;
 	/**
 	 * Will add/remove a given gameplay tag to the ASC based on the bool inputted.
 	 * Call this function on Prediction Tick.
 	 * A good example of this is something like a State.InAir tag.
 	 */
 	UFUNCTION(BlueprintCallable)
-	void MatchTagToBool(FGameplayTag InTag, bool MatchedBool);
+	void MatchTagToBool(const FGameplayTag& InTag, bool MatchedBool);
 
 	// A UGMCAttributesData asset that defines the default attributes for this component
 	UPROPERTY(EditDefaultsOnly, DisplayName="Attributes")


### PR DESCRIPTION
This now has:

* `HasTag` (single gameplay tag)
* `HasTagExact` (single gameplay tag, exact match)
* `HasAnyTag` (gameplay tag container)
* `HasAnyTagExact` (gameplay tag container, exact match)
* `HasAllTags` (gameplay tag container)
* `HasAllTagsExact` (gameplay tag container, exact match)

In addition, I took the opportunity to change most of our gameplay tag parameters to const pass-by-reference where viable, just so we're not creating extra copies needlessly.