### PR TITLE
Additional animation utility functionality

### DIFF
--- a/Source/GMCAbilitySystem/Private/Actors/GMAS_Pawn.cpp
+++ b/Source/GMCAbilitySystem/Private/Actors/GMAS_Pawn.cpp
@@ -1,0 +1,75 @@
+﻿#include "Actors/GMAS_Pawn.h"
+
+#include "EnhancedInputComponent.h"
+#include "EnhancedInputSubsystems.h"
+#include "Camera/CameraComponent.h"
+#include "Components/CapsuleComponent.h"
+#include "GameFramework/SpringArmComponent.h"
+#include "Utility/GMASUtilities.h"
+
+
+// Sets default values
+AGMAS_Pawn::AGMAS_Pawn(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
+{
+	// Set this pawn to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+
+	CapsuleComponent = CreateDefaultSubobject<UCapsuleComponent>(TEXT("Capsule"));
+	SetRootComponent(CapsuleComponent);
+	CapsuleComponent->SetCapsuleRadius(30.f);
+	CapsuleComponent->SetCapsuleHalfHeight(90.f);
+	CapsuleComponent->bEditableWhenInherited = true;
+	CapsuleComponent->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
+	CapsuleComponent->SetCollisionObjectType(ECC_Pawn);
+	CapsuleComponent->SetCollisionResponseToAllChannels(ECR_Block);
+	CapsuleComponent->SetCollisionResponseToChannel(ECC_Camera, ECR_Ignore);
+	CapsuleComponent->SetCollisionResponseToChannel(ECC_Visibility, ECR_Ignore);
+	
+	MeshComponent = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("Skeletal Mesh"));
+	MeshComponent->bEditableWhenInherited = true;
+	MeshComponent->SetupAttachment(CapsuleComponent);
+	MeshComponent->SetRelativeLocation(FVector(0.f, 0.f, -90.f));
+	MeshComponent->SetRelativeRotation(FRotator(0.f, -90.f, 0.f));
+	MeshComponent->SetCollisionProfileName(TEXT("NoCollision"));
+	
+	SpringArmComponent = CreateDefaultSubobject<USpringArmComponent>(TEXT("Spring Arm"));
+	SpringArmComponent->bEditableWhenInherited = true;
+	SpringArmComponent->SetupAttachment(CapsuleComponent);
+	SpringArmComponent->TargetArmLength = 400.f;
+	SpringArmComponent->bUsePawnControlRotation = true;
+
+	CameraComponent = CreateDefaultSubobject<UCameraComponent>(TEXT("Follow Camera"));
+	CameraComponent->bEditableWhenInherited = true;
+	CameraComponent->SetupAttachment(SpringArmComponent);
+	CameraComponent->bUsePawnControlRotation = false;
+
+	// Add our basic goodies.
+	AbilitySystemComponent = CreateDefaultSubobject<UGMC_AbilitySystemComponent>(TEXT("Ability Component"));
+
+#if WITH_EDITOR
+	UGMASUtilities::SetPropertyFlagsSafe(StaticClass(), TEXT("CapsuleComponent"), CPF_DisableEditOnInstance);
+	UGMASUtilities::SetPropertyFlagsSafe(StaticClass(), TEXT("MeshComponent"), CPF_DisableEditOnInstance);
+	UGMASUtilities::SetPropertyFlagsSafe(StaticClass(), TEXT("SpringArmComponent"), CPF_DisableEditOnInstance);
+	UGMASUtilities::SetPropertyFlagsSafe(StaticClass(), TEXT("CameraComponent"), CPF_DisableEditOnInstance);
+	UGMASUtilities::SetPropertyFlagsSafe(StaticClass(), TEXT("AbilitySystemComponent"), CPF_DisableEditOnInstance);
+#endif
+}
+
+// Called to bind functionality to input
+void AGMAS_Pawn::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
+{
+	if (const UEnhancedInputComponent* EnhancedInput = Cast<UEnhancedInputComponent>(PlayerInputComponent); InputMappingContext && EnhancedInput)
+	{
+		if (const ULocalPlayer* Player = Cast<ULocalPlayer>(GetController()))
+		{
+			if (UEnhancedInputLocalPlayerSubsystem* InputSystem = Player->GetSubsystem<UEnhancedInputLocalPlayerSubsystem>())
+			{
+				// Add our default system as the lowest mapping context.
+				InputSystem->AddMappingContext(InputMappingContext, 0);
+			}
+		}
+	}
+
+	Super::SetupPlayerInputComponent(PlayerInputComponent);
+}
+

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -410,6 +410,7 @@ void UGMC_AbilitySystemComponent::BeginPlay()
 	Super::BeginPlay();
 	InitializeStartingAbilities();
 	InitializeAbilityMap();
+	SetStartingTags();
 }
 
 void UGMC_AbilitySystemComponent::InstantiateAttributes()
@@ -435,6 +436,11 @@ void UGMC_AbilitySystemComponent::InstantiateAttributes()
 			}
 		}
 	}
+}
+
+void UGMC_AbilitySystemComponent::SetStartingTags()
+{
+	ActiveTags.AppendTags(StartingTags);
 }
 
 void UGMC_AbilitySystemComponent::CleanupStaleAbilities()

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -100,7 +100,7 @@ void UGMC_AbilitySystemComponent::BindReplicationData()
 		EGMC_InterpolationFunction::TargetValue);
 
 	// Attributes
-	BindInstancedStruct(BoundAttributes,
+	GMCMovementComponent->BindInstancedStruct(BoundAttributes,
 		EGMC_PredictionMode::ServerAuth_Output_ClientValidated,
 		EGMC_CombineMode::CombineIfUnchanged,
 		EGMC_SimulationMode::Periodic_Output,
@@ -121,7 +121,7 @@ void UGMC_AbilitySystemComponent::BindReplicationData()
 		EGMC_InterpolationFunction::TargetValue);
 	
 	// TaskData Bind
-	BindInstancedStruct(TaskData,
+	GMCMovementComponent->BindInstancedStruct(TaskData,
 		EGMC_PredictionMode::ClientAuth_Input,
 		EGMC_CombineMode::CombineIfUnchanged,
 		EGMC_SimulationMode::None,

--- a/Source/GMCAbilitySystem/Private/Debug/GameplayDebuggerCategory_GMCAbilitySystem.cpp
+++ b/Source/GMCAbilitySystem/Private/Debug/GameplayDebuggerCategory_GMCAbilitySystem.cpp
@@ -17,16 +17,23 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::CollectData(APlayerController* 
 {
 	if (OwnerPC)
 	{
-		DataPack.ActorName = OwnerPC->GetPawn()->GetName();
-
-		if (const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>())
+		if (OwnerPC->GetPawn())
 		{
-			DataPack.GrantedAbilities = AbilityComponent->GetGrantedAbilities().ToStringSimple();
-			DataPack.ActiveTags = AbilityComponent->GetActiveTags().ToStringSimple();
-			DataPack.Attributes = AbilityComponent->GetAllAttributesString();
-			DataPack.ActiveEffects = AbilityComponent->GetActiveEffectsString();
-			DataPack.ActiveEffectData = AbilityComponent->GetActiveEffectsDataString();
-			DataPack.ActiveAbilities = AbilityComponent->GetActiveAbilitiesString();
+			DataPack.ActorName = OwnerPC->GetPawn()->GetName();
+
+			if (const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>())
+			{
+				DataPack.GrantedAbilities = AbilityComponent->GetGrantedAbilities().ToStringSimple();
+				DataPack.ActiveTags = AbilityComponent->GetActiveTags().ToStringSimple();
+				DataPack.Attributes = AbilityComponent->GetAllAttributesString();
+				DataPack.ActiveEffects = AbilityComponent->GetActiveEffectsString();
+				DataPack.ActiveEffectData = AbilityComponent->GetActiveEffectsDataString();
+				DataPack.ActiveAbilities = AbilityComponent->GetActiveAbilitiesString();
+			}
+		}
+		else
+		{
+			DataPack.ActorName = TEXT("Spectator or missing pawn");
 		}
 	}
 }
@@ -37,7 +44,7 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::DrawData(APlayerController* Own
 	if (!DataPack.ActorName.IsEmpty())
 	{
 		CanvasContext.Printf(TEXT("{yellow}Actor name: {white}%s"), *DataPack.ActorName);
-		const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>();
+		const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn() ? OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>() : nullptr;
 		if (AbilityComponent == nullptr) return;
 
 		// Abilities

--- a/Source/GMCAbilitySystem/Private/Utility/GMASUtilities.cpp
+++ b/Source/GMCAbilitySystem/Private/Utility/GMASUtilities.cpp
@@ -1,0 +1,23 @@
+﻿#include "Utility/GMASUtilities.h"
+
+#if WITH_EDITOR
+void UGMASUtilities::SetPropertyFlagsSafe(UClass* StaticClass, FName PropertyName, EPropertyFlags NewFlags)
+{
+	if (!StaticClass) return;
+
+	if (FProperty *Property = StaticClass->FindPropertyByName(PropertyName))
+	{
+		Property->SetPropertyFlags(NewFlags);
+	}	
+}
+
+void UGMASUtilities::ClearPropertyFlagsSafe(UClass* StaticClass, FName PropertyName, EPropertyFlags ClearFlags)
+{
+	if (!StaticClass) return;
+
+	if (FProperty *Property = StaticClass->FindPropertyByName(PropertyName))
+	{
+		Property->ClearPropertyFlags(ClearFlags);
+	}	
+}
+#endif

--- a/Source/GMCAbilitySystem/Private/Utility/GameplayElementMapping.cpp
+++ b/Source/GMCAbilitySystem/Private/Utility/GameplayElementMapping.cpp
@@ -215,6 +215,11 @@ void FGMCGameplayElementTagPropertyMap::ApplyCurrentAttributes()
 	}
 }
 
+bool FGMCGameplayElementTagPropertyMap::IsInitialized() const
+{
+	return CachedAbilityComponent.IsValid();
+}
+
 void FGMCGameplayElementTagPropertyMap::Unregister()
 {
 	if (UGMC_AbilitySystemComponent* AbilityComponent = CachedAbilityComponent.Get())

--- a/Source/GMCAbilitySystem/Public/Actors/GMAS_Pawn.h
+++ b/Source/GMCAbilitySystem/Public/Actors/GMAS_Pawn.h
@@ -1,0 +1,57 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "GMCAbilityComponent.h"
+#include "GMCPawn.h"
+#include "InputMappingContext.h"
+#include "GMAS_Pawn.generated.h"
+
+class UCameraComponent;
+class USpringArmComponent;
+
+
+/**
+ * The GMAS Pawn is a generic pawn which contains a pre-set-up capsule, spring arm, camera,
+ * and so on, as well as an ability system component. It will also automatically set up the input mapping context
+ * if one is provided. This pawn is *purely* a convenience class; it is not required to use anything in GMAS.
+ * 
+ * A movement component is *not* pre-set-up, because people will almost always want to use their own subclass,
+ * and that would be difficult to override in Blueprints.
+ */
+UCLASS(ClassGroup=(GMAS), meta=(DisplayName="GMAS Pawn"))
+class GMCABILITYSYSTEM_API AGMAS_Pawn : public AGMC_Pawn
+{
+	GENERATED_BODY()
+
+public:
+	// Sets default values for this pawn's properties
+	AGMAS_Pawn(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
+
+public:
+
+	// Called to bind functionality to input
+	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
+
+protected:
+
+	// A convenience setting; if this is set, the given input mapping context will be added with
+	// priority 0 automatically.
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Input")
+	TObjectPtr<UInputMappingContext> InputMappingContext;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Components", DisplayName="Capsule", meta=(AllowPrivateAccess=true))
+	TObjectPtr<UCapsuleComponent> CapsuleComponent;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Components", DisplayName="Skeletal Mesh", meta=(AllowPrivateAccess=true))
+	TObjectPtr<USkeletalMeshComponent> MeshComponent;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Components", DisplayName="Spring Arm", meta=(AllowPrivateAccess=true))
+	TObjectPtr<USpringArmComponent> SpringArmComponent;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Components", DisplayName="Follow Camera", meta=(AllowPrivateAccess=true))
+	TObjectPtr<UCameraComponent> CameraComponent;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Components")
+	TObjectPtr<UGMC_AbilitySystemComponent> AbilitySystemComponent;
+
+};

--- a/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
+++ b/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "CoreMinimal.h"
+#include "GMCPawn.h"
 #include "Animation/AnimInstance.h"
 #include "Utility/GameplayElementMapping.h"
 #include "GMCAbilityAnimInstance.generated.h"
@@ -24,6 +25,11 @@ public:
 	
 protected:
 
+#if WITH_EDITORONLY_DATA
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Ability System")
+	TSubclassOf<AGMC_Pawn> EditorPreviewClass { AGMC_Pawn::StaticClass() };
+#endif
+	
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category="Ability System")
 	AGMC_Pawn* GMCPawn;
 	

--- a/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
+++ b/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
@@ -12,12 +12,14 @@ class UGMC_AbilitySystemComponent;
  * set to the owner's ability system (if present), and a "Tag Property Map" allows any valid gameplay tag to be
  * mapped automatically to properties.
  */
-UCLASS()
+UCLASS(ClassGroup="Animation", meta=(DisplayName="GMAS Animation Blueprint"))
 class GMCABILITYSYSTEM_API UGMCAbilityAnimInstance : public UAnimInstance
 {
 	GENERATED_BODY()
 
 public:
+	UGMCAbilityAnimInstance(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
+	
 	virtual void NativeBeginPlay() override;
 	virtual void NativeInitializeAnimation() override;
 
@@ -30,12 +32,14 @@ protected:
 	TSubclassOf<AGMC_Pawn> EditorPreviewClass { AGMC_Pawn::StaticClass() };
 #endif
 	
-	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category="Ability System")
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, AdvancedDisplay, Category="Ability System", meta=(EditConditionHides))
 	AGMC_Pawn* GMCPawn;
 	
-	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category="Ability System")
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, AdvancedDisplay, Category="Ability System", meta=(EditConditionHides))
 	UGMC_AbilitySystemComponent* AbilitySystemComponent;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Ability System")
 	FGMCGameplayElementTagPropertyMap TagPropertyMap;
+
+	friend UGMC_AbilitySystemComponent;
 };

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -312,26 +312,6 @@ protected:
 	FGMCAbilityData AbilityData;
 	FInstancedStruct TaskData = FInstancedStruct::Make(FGMCAbilityTaskData{});;
 
-	// FInstancedStruct GMC Binding
-	UFUNCTION(BlueprintCallable)
-	int32 BindInstancedStruct(
-	  UPARAM(Ref) FInstancedStruct& VariableToBind,
-	  EGMC_PredictionMode PredictionMode,
-	  EGMC_CombineMode CombineMode,
-	  EGMC_SimulationMode SimulationMode,
-	  EGMC_InterpolationFunction Interpolation
-	)
-	{
-		int32 BindingIndex = -1;
-				GMCMovementComponent->AliasData.InstancedStruct.BindMember(
-				  VariableToBind,
-				  TranslateToSyncSettings(PredictionMode, CombineMode, SimulationMode, Interpolation),
-				  BindingIndex
-				);
-		return BindingIndex;
-	}
-
-
 private:
 
 	// Array of data objects to initialize the component's ability map

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -14,6 +14,7 @@
 #include "GMCAbilityComponent.generated.h"
 
 
+class UGMCAbilityAnimInstance;
 class UGMCAbilityMapData;
 class UGMCAttributesData;
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnPreAttributeChanged, UGMCAttributeModifierContainer*, AttributeModifierContainer, UGMC_AbilitySystemComponent*,
@@ -42,7 +43,7 @@ struct FEffectStatePrediction
 
 class UGMCAbility;
 
-UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent, DisplayName="GMC Ability System Component"))
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent, DisplayName="GMC Ability System Component"), meta=(Categories="GMAS"))
 class GMCABILITYSYSTEM_API UGMC_AbilitySystemComponent : public UGameplayTasksComponent //  : public UGMC_MovementUtilityCmp
 {
 	GENERATED_BODY()
@@ -64,10 +65,10 @@ public:
 	// Return the active ability effects
 	TMap<int, UGMCAbilityEffect*> GetActiveEffects() const { return ActiveEffects; }
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="GMAS|Abilities")
 	void AddAbilityMapData(UGMCAbilityMapData* AbilityMapData);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="GMAS|Abilities")
 	void RemoveAbilityMapData(UGMCAbilityMapData* AbilityMapData);
 		
 	// Add an ability to the GrantedAbilities array
@@ -103,7 +104,7 @@ public:
 	bool TryActivateAbility(TSubclassOf<UGMCAbility> ActivatedAbility, const UInputAction* InputAction = nullptr);
 	
 	// Queue an ability to be executed
-	UFUNCTION(BlueprintCallable, DisplayName="Activate Ability", Category="Ability", meta=(Categories="Ability"))
+	UFUNCTION(BlueprintCallable, DisplayName="Activate Ability", Category="GMAS|Abilities")
 	void QueueAbility(UPARAM(meta=(Categories="Input"))FGameplayTag InputTag, const UInputAction* InputAction = nullptr);
 
 	void QueueTaskData(const FInstancedStruct& TaskData);
@@ -147,27 +148,27 @@ public:
 	 * @param	bOverwriteExistingModifiers	Whether or not to replace existing modifiers that have the same name as additional modifiers. If false, will add them.
 	 * @param	bAppliedByServer	Is this Effect only applied by server? Used to help client predict the unpredictable.
 	 */
-	UFUNCTION(BlueprintCallable, meta = (AutoCreateRefTerm = "AdditionalModifiers"))
+	UFUNCTION(BlueprintCallable, Category="GMAS|Effects", meta = (AutoCreateRefTerm = "AdditionalModifiers"))
 	UGMCAbilityEffect* ApplyAbilityEffect(TSubclassOf<UGMCAbilityEffect> Effect, FGMCAbilityEffectData InitializationData);
 	
 	UGMCAbilityEffect* ApplyAbilityEffect(UGMCAbilityEffect* Effect, FGMCAbilityEffectData InitializationData);
 
 	
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="GMAS|Effects")
 	void RemoveActiveAbilityEffect(UGMCAbilityEffect* Effect);
 
 	/**
 	 * Removes an instanced effect if it exists. If NumToRemove == -1, remove all. Returns the number of removed instances.
 	 * If the inputted count is higher than the number of active corresponding effects, remove all we can.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="GMAS|Effects")
 	int32 RemoveEffectByTag(FGameplayTag InEffectTag, int32 NumToRemove=-1);
 
 	/**
 	 * Gets the number of active effects with the inputted tag.
 	 * Returns -1 if tag is invalid.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="GMAS|Effects")
 	int32 GetNumEffectByTag(FGameplayTag InEffectTag);
 
 	//// Event Delegates
@@ -197,30 +198,30 @@ public:
 	const FAttribute* GetAttributeByTag(FGameplayTag AttributeTag) const;
 
 	// Get Attribute value by Tag
-	UFUNCTION(BlueprintPure, Category="GMCAbilitySystem")
+	UFUNCTION(BlueprintPure, Category="GMAS|Attributes")
 	float GetAttributeValueByTag(UPARAM(meta=(Categories="Attribute"))FGameplayTag AttributeTag) const;
 
 	// Set Attribute value by Tag
 	// Will NOT trigger an "OnAttributeChanged" Event
 	// bResetModifiers: Will reset all modifiers on the attribute to the base value. DO NOT USE if you have any active effects that modify this attribute.
-	UFUNCTION(BlueprintCallable, Category="GMCAbilitySystem")
+	UFUNCTION(BlueprintCallable, Category="GMAS|Attributes")
 	bool SetAttributeValueByTag(UPARAM(meta=(Categories="Attribute"))FGameplayTag AttributeTag, float NewValue, bool bResetModifiers = false);
 	
 	/** Get the default value of an attribute from the data assets. */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="GMAS|Attributes")
 	float GetBaseAttributeValueByTag(UPARAM(meta=(Categories="Attribute"))FGameplayTag AttributeTag) const;
 	
 	// Apply modifiers that affect attributes
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="GMAS|Attributes")
 	void ApplyAbilityEffectModifier(FGMCAttributeModifier AttributeModifier, bool bNegateValue = false, UGMC_AbilitySystemComponent* SourceAbilityComponent = nullptr);
 
 	UPROPERTY(BlueprintReadWrite)
 	bool bJustTeleported;
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="GMAS")
 	bool HasAuthority() const { return GetOwnerRole() == ROLE_Authority; }
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, AdvancedDisplay)
 	UGMC_MovementUtilityCmp* GMCMovementComponent;
 
 	UFUNCTION(Server, Reliable)
@@ -257,20 +258,20 @@ public:
 
 #pragma region GMC
 	// GMC
-	UFUNCTION(BlueprintCallable, Category="GMCAbilitySystem")
+	UFUNCTION(BlueprintCallable, Category="GMAS")
 	virtual void BindReplicationData();
 	
-	UFUNCTION(BlueprintCallable, Category="GMCAbilitySystem")
+	UFUNCTION(BlueprintCallable, Category="GMAS")
 	virtual void GenAncillaryTick(float DeltaTime, bool bIsCombinedClientMove);
 
 
-	UFUNCTION(BlueprintCallable, Category="GMCAbilitySystem")
+	UFUNCTION(BlueprintCallable, Category="GMAS")
 	virtual void GenPredictionTick(float DeltaTime);
 
-	UFUNCTION(BlueprintCallable, Category="GMCAbilitySystem")
+	UFUNCTION(BlueprintCallable, Category="GMAS")
 	virtual void GenSimulationTick(float DeltaTime);
 
-	UFUNCTION(BlueprintCallable, Category="GMCAbilitySystem")
+	UFUNCTION(BlueprintCallable, Category="GMAS")
 	virtual void PreLocalMoveExecution();
 
 #pragma endregion GMC
@@ -299,11 +300,14 @@ protected:
 	// Effect tags that are granted to the player (bound)
 	FGameplayTagContainer ActiveTags;
 
-	UPROPERTY(EditAnywhere, meta=(Categories="Ability"))
+	UPROPERTY(EditDefaultsOnly, Category="Ability")
 	FGameplayTagContainer StartingAbilities;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditDefaultsOnly, Category="Ability")
 	TArray<TSubclassOf<UGMCAbilityEffect>> StartingEffects;
+
+	UPROPERTY(EditDefaultsOnly, Category="Tags")
+	FGameplayTagContainer StartingTags;
 	
 	// Returns the matching abilities in the AbilityMap if they have been granted
 	TArray<TSubclassOf<UGMCAbility>> GetGrantedAbilitiesByTag(FGameplayTag AbilityTag);
@@ -315,7 +319,7 @@ protected:
 private:
 
 	// Array of data objects to initialize the component's ability map
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category="Ability")
 	TArray<TObjectPtr<UGMCAbilityMapData>> AbilityMaps;
 	
 	// Map of Ability Tags to Ability Classes
@@ -359,6 +363,8 @@ private:
 	// This must run before variable binding
 	void InstantiateAttributes();
 
+	void SetStartingTags();
+	
 	// Clear out abilities in the Ended state from the ActivateAbilities map
 	void CleanupStaleAbilities();
 
@@ -412,5 +418,7 @@ private:
 	// this is just for redundancy
 	UFUNCTION(Client, Reliable)
 	void RPCClientEndEffect(int EffectID);
+
+	friend UGMCAbilityAnimInstance;
 		
 };

--- a/Source/GMCAbilitySystem/Public/Utility/GMASUtilities.h
+++ b/Source/GMCAbilitySystem/Public/Utility/GMASUtilities.h
@@ -1,0 +1,22 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "GMASUtilities.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class GMCABILITYSYSTEM_API UGMASUtilities : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+public:
+	// Editor-specific helper functions. Not actually for Blueprints.
+#if WITH_EDITOR
+	static void SetPropertyFlagsSafe(UClass* StaticClass, FName PropertyName, EPropertyFlags NewFlags);
+	static void ClearPropertyFlagsSafe(UClass* StaticClass, FName PropertyName, EPropertyFlags ClearFlags);
+#endif
+	
+};

--- a/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
+++ b/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
@@ -64,6 +64,8 @@ public:
 	void ApplyCurrentTags();
 	void ApplyCurrentAttributes();
 
+	bool IsInitialized() const;
+
 #if WITH_EDITOR
 	EDataValidationResult IsDataValid(const UObject* ContainingAsset, FDataValidationContext& Context) const;
 #endif
@@ -89,5 +91,4 @@ protected:
 
 	UPROPERTY(EditAnywhere)
 	TArray<FGMCGameplayElementTagPropertyMapping> PropertyMappings;
-	
 };


### PR DESCRIPTION
This will:
* Cleanly handle the scenario where the preview pawn is lacking an ability system component, e.g. was set up in blueprint.
* Adds a GMAS_Pawn convenience class -- totally optional -- which sets up the capsule, mesh, camera, and an ability component. It also will automatically add the input mapping context for you if you set one in the defaults.

(I also cleaned up a bunch of the function/property categories, because it was driving me a tiny bit nuts.)

This branches off the rest of the dev branch cleanups, so apply that PR first (or delete it if doing this one first).