### PR TITLE
Change attributes to use net deltas.

### DIFF
--- a/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
+++ b/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
@@ -18,6 +18,7 @@ public class GMCAbilitySystem : ModuleRules
 				"GameplayTasks",
 				"GameplayTags",
 				"GameplayDebugger",
+				"NetCore",
 				"StructUtils"
 				// ... add other public dependencies that you statically link with here ...
 			}

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -888,7 +888,16 @@ bool UGMC_AbilitySystemComponent::SetAttributeValueByTag(FGameplayTag AttributeT
 		{
 			Att->ResetModifiers();
 		}
-		
+
+		if (Att->bIsGMCBound)
+		{
+			BoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AttributeTag);
+		}
+		else
+		{
+			UnBoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AttributeTag);
+		}
+
 		return true;
 	}
 	return false;
@@ -967,6 +976,15 @@ void UGMC_AbilitySystemComponent::ApplyAbilityEffectModifier(FGMCAttributeModifi
 		}
 		AffectedAttribute->ApplyModifier(AttributeModifier);
 
+		if (AffectedAttribute->bIsGMCBound)
+		{
+			BoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AffectedAttribute->Tag);
+		}
+		else
+		{
+			UnBoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AffectedAttribute->Tag);
+		}
+		
 		OnAttributeChanged.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
 		NativeAttributeChangeDelegate.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
 	}

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -1,10 +1,11 @@
 ﻿#pragma once
 #include "GameplayTagContainer.h"
 #include "Effects/GMCAbilityEffect.h"
+#include "Net/Serialization/FastArraySerializer.h"
 #include "GMCAttributes.generated.h"
 
 USTRUCT(BlueprintType)
-struct GMCABILITYSYSTEM_API FAttribute
+struct GMCABILITYSYSTEM_API FAttribute : public FFastArraySerializerItem
 {
 	GENERATED_BODY()
 	FAttribute(){};
@@ -90,7 +91,8 @@ struct GMCABILITYSYSTEM_API FAttribute
 };
 
 USTRUCT()
-struct GMCABILITYSYSTEM_API FGMCAttributeSet{
+struct GMCABILITYSYSTEM_API FGMCAttributeSet : public FFastArraySerializer
+{
 	GENERATED_BODY()
 
 	UPROPERTY()
@@ -99,5 +101,30 @@ struct GMCABILITYSYSTEM_API FGMCAttributeSet{
 	void AddAttribute(FAttribute NewAttribute) {Attributes.Add(NewAttribute);}
 
 	TArray<FAttribute> GetAttributes() const{return Attributes;}
+
+	bool NetDeltaSerialize(FNetDeltaSerializeInfo & DeltaParms)
+	{
+		return FFastArraySerializer::FastArrayDeltaSerialize<FAttribute, FGMCAttributeSet>( Attributes, DeltaParms, *this );
+	}
+
+	void MarkAttributeDirtyByTag(FGameplayTag AttributeTag)
+	{
+		for (auto& Attribute : Attributes)
+		{
+			if (Attribute.Tag.MatchesTag(AttributeTag))
+			{
+				MarkItemDirty(Attribute);
+			}
+		}
+	}
+};
+
+template<>
+struct TStructOpsTypeTraits< FGMCAttributeSet > : public TStructOpsTypeTraitsBase2< FGMCAttributeSet >
+{
+	enum 
+	{
+		WithNetDeltaSerializer = true,
+   };
 };
 


### PR DESCRIPTION
This changes `FGMCAttributeSet` to utilize the "fast net array serialization." The long and short of it is that now attributes should only send changes to their values, not the entire attribute set.

(Yay! Efficiency!)