### PR TITLE
Attribute refactor

### DIFF
--- a/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
+++ b/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
@@ -18,6 +18,7 @@ public class GMCAbilitySystem : ModuleRules
 				"GameplayTasks",
 				"GameplayTags",
 				"GameplayDebugger",
+				"NetCore",
 				"StructUtils"
 				// ... add other public dependencies that you statically link with here ...
 			}

--- a/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
+++ b/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
@@ -18,7 +18,6 @@ public class GMCAbilitySystem : ModuleRules
 				"GameplayTasks",
 				"GameplayTags",
 				"GameplayDebugger",
-				"NetCore",
 				"StructUtils"
 				// ... add other public dependencies that you statically link with here ...
 			}

--- a/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
+++ b/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
@@ -44,6 +44,7 @@ public class GMCAbilitySystem : ModuleRules
 		
 		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
 		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public/Components"));
+		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public/Attributes"));
 		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
 	}
 }

--- a/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeClamp.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeClamp.cpp
@@ -1,0 +1,32 @@
+﻿#pragma once
+#include "Attributes/GMCAttributeClamp.h"
+
+#include "GMCAbilityComponent.h"
+
+float FAttributeClamp::ClampValue(float Value) const
+{
+	// Clamp not set, return Value
+	if (this == FAttributeClamp{}){return Value;}
+
+	// No AbilityComponent, clamp to Min and Max
+	if (!AbilityComponent)
+	{
+		return FMath::Clamp(Value, Min, Max);
+	}
+
+	float AttributeMin = Min;
+	float AttributeMax = Max;
+	
+	// Get MinAttributeTag value
+	if (MinAttributeTag.IsValid())
+	{
+		AttributeMin = AbilityComponent->GetAttributeValueByTag(MinAttributeTag);
+	}
+
+	if (MaxAttributeTag.IsValid())
+	{
+		AttributeMax = AbilityComponent->GetAttributeValueByTag(MaxAttributeTag);
+	}
+	
+	return FMath::Clamp(Value, AttributeMin, AttributeMax);
+}

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -896,7 +896,7 @@ bool UGMC_AbilitySystemComponent::SetAttributeValueByTag(FGameplayTag AttributeT
 {
 	if (const FAttribute* Att = GetAttributeByTag(AttributeTag))
 	{
-		Att->Value = NewValue;
+		Att->BaseValue = NewValue;
 
 		if (bResetModifiers)
 		{
@@ -956,7 +956,7 @@ FString UGMC_AbilitySystemComponent::GetActiveAbilitiesString() const{
 
 #pragma endregion  ToStringHelpers
 
-void UGMC_AbilitySystemComponent::ApplyAbilityEffectModifier(FGMCAttributeModifier AttributeModifier, bool bNegateValue, UGMC_AbilitySystemComponent* SourceAbilityComponent)
+void UGMC_AbilitySystemComponent::ApplyAbilityEffectModifier(FGMCAttributeModifier AttributeModifier, bool bModifyBaseValue, bool bNegateValue,  UGMC_AbilitySystemComponent* SourceAbilityComponent)
 {
 	// Provide an opportunity to modify the attribute modifier before applying it
 	UGMCAttributeModifierContainer* AttributeModifierContainer = NewObject<UGMCAttributeModifierContainer>(this);
@@ -979,7 +979,7 @@ void UGMC_AbilitySystemComponent::ApplyAbilityEffectModifier(FGMCAttributeModifi
 		{
 			AttributeModifier.Value = -AttributeModifier.Value;
 		}
-		AffectedAttribute->ApplyModifier(AttributeModifier);
+		AffectedAttribute->ApplyModifier(AttributeModifier, bModifyBaseValue);
 
 		OnAttributeChanged.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
 		NativeAttributeChangeDelegate.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -902,16 +902,7 @@ bool UGMC_AbilitySystemComponent::SetAttributeValueByTag(FGameplayTag AttributeT
 		{
 			Att->ResetModifiers();
 		}
-
-		if (Att->bIsGMCBound)
-		{
-			BoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AttributeTag);
-		}
-		else
-		{
-			UnBoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AttributeTag);
-		}
-
+		
 		return true;
 	}
 	return false;
@@ -990,15 +981,6 @@ void UGMC_AbilitySystemComponent::ApplyAbilityEffectModifier(FGMCAttributeModifi
 		}
 		AffectedAttribute->ApplyModifier(AttributeModifier);
 
-		if (AffectedAttribute->bIsGMCBound)
-		{
-			BoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AffectedAttribute->Tag);
-		}
-		else
-		{
-			UnBoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AffectedAttribute->Tag);
-		}
-		
 		OnAttributeChanged.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
 		NativeAttributeChangeDelegate.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
 	}

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -429,8 +429,10 @@ void UGMC_AbilitySystemComponent::InstantiateAttributes()
 			FAttribute NewAttribute;
 			NewAttribute.Tag = AttributeData.AttributeTag;
 			NewAttribute.BaseValue = AttributeData.DefaultValue;
+			NewAttribute.Clamp = AttributeData.Clamp;
+			NewAttribute.Clamp.AbilityComponent = this;
 			NewAttribute.bIsGMCBound = AttributeData.bGMCBound;
-			NewAttribute.CalculateValue();
+			NewAttribute.Init();
 			
 			if(AttributeData.bGMCBound){
 				BoundAttributes.GetMutable<FGMCAttributeSet>().AddAttribute(NewAttribute);
@@ -439,6 +441,18 @@ void UGMC_AbilitySystemComponent::InstantiateAttributes()
 				UnBoundAttributes.GetMutable<FGMCAttributeSet>().AddAttribute(NewAttribute);
 			}
 		}
+	}
+
+	// After all attributes are initialized, calc their values which will primarily apply their Clamps
+	
+	for (const FAttribute& Attribute : BoundAttributes.Get<FGMCAttributeSet>().Attributes)
+	{
+		Attribute.CalculateValue();
+	}
+
+	for (const FAttribute& Attribute : UnBoundAttributes.Get<FGMCAttributeSet>().Attributes)
+	{
+		Attribute.CalculateValue();
 	}
 }
 

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -896,7 +896,7 @@ bool UGMC_AbilitySystemComponent::SetAttributeValueByTag(FGameplayTag AttributeT
 {
 	if (const FAttribute* Att = GetAttributeByTag(AttributeTag))
 	{
-		Att->BaseValue = NewValue;
+		Att->SetBaseValue(NewValue);
 
 		if (bResetModifiers)
 		{

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -902,7 +902,16 @@ bool UGMC_AbilitySystemComponent::SetAttributeValueByTag(FGameplayTag AttributeT
 		{
 			Att->ResetModifiers();
 		}
-		
+
+		if (Att->bIsGMCBound)
+		{
+			BoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AttributeTag);
+		}
+		else
+		{
+			UnBoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AttributeTag);
+		}
+
 		return true;
 	}
 	return false;
@@ -981,6 +990,15 @@ void UGMC_AbilitySystemComponent::ApplyAbilityEffectModifier(FGMCAttributeModifi
 		}
 		AffectedAttribute->ApplyModifier(AttributeModifier);
 
+		if (AffectedAttribute->bIsGMCBound)
+		{
+			BoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AffectedAttribute->Tag);
+		}
+		else
+		{
+			UnBoundAttributes.GetMutable<FGMCAttributeSet>().MarkAttributeDirtyByTag(AffectedAttribute->Tag);
+		}
+		
 		OnAttributeChanged.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
 		NativeAttributeChangeDelegate.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
 	}

--- a/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
+++ b/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
@@ -73,10 +73,11 @@ void UGMCAbilityEffect::StartEffect()
 			OwnerAbilityComponent->ApplyAbilityEffectModifier(Modifier, true);
 		}
 		EndEffect();
+		return;
 	}
 
 	// Duration Effects that aren't periodic alter modifiers, not base
-	if (EffectData.Period == 0)
+	if (!EffectData.bIsInstant && EffectData.Period == 0)
 	{
 		EffectData.bNegateEffectAtEnd = true;
 		for (const FGMCAttributeModifier& Modifier : EffectData.Modifiers)

--- a/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
+++ b/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
@@ -65,12 +65,23 @@ void UGMCAbilityEffect::StartEffect()
 	AddTagsToOwner();
 	AddAbilitiesToOwner();
 
-	// Duration and Instant applies immediately.
-	if (EffectData.Period == 0)
+	// Instant effects modify base value and end instantly
+	if (EffectData.bIsInstant)
 	{
 		for (const FGMCAttributeModifier& Modifier : EffectData.Modifiers)
 		{
-			OwnerAbilityComponent->ApplyAbilityEffectModifier(Modifier);
+			OwnerAbilityComponent->ApplyAbilityEffectModifier(Modifier, true);
+		}
+		EndEffect();
+	}
+
+	// Duration Effects that aren't periodic alter modifiers, not base
+	if (EffectData.Period == 0)
+	{
+		EffectData.bNegateEffectAtEnd = true;
+		for (const FGMCAttributeModifier& Modifier : EffectData.Modifiers)
+		{
+			OwnerAbilityComponent->ApplyAbilityEffectModifier(Modifier, false);
 		}
 	}
 
@@ -103,11 +114,11 @@ void UGMCAbilityEffect::EndEffect()
 	// Only remove tags and abilities if the effect has started
 	if (!bHasStarted) return;
 
-	if (EffectData.bNegateEffectAtEnd && !EffectData.bIsInstant)
+	if (EffectData.bNegateEffectAtEnd)
 	{
 		for (const FGMCAttributeModifier& Modifier : EffectData.Modifiers)
 		{
-			OwnerAbilityComponent->ApplyAbilityEffectModifier(Modifier, true);
+			OwnerAbilityComponent->ApplyAbilityEffectModifier(Modifier, false, true);
 		}
 	}
 	
@@ -150,7 +161,7 @@ void UGMCAbilityEffect::PeriodTick()
 {
 	for (const FGMCAttributeModifier& AttributeModifier : EffectData.Modifiers)
 	{
-		OwnerAbilityComponent->ApplyAbilityEffectModifier(AttributeModifier);
+		OwnerAbilityComponent->ApplyAbilityEffectModifier(AttributeModifier, true);
 	}
 }
 

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
@@ -16,7 +16,7 @@ struct GMCABILITYSYSTEM_API FAttributeClamp
 
 	// Value will be clamped to the value of this attribute
 	// If set, this will take priority over Min
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"))
 	FGameplayTag MinAttributeTag;
 
 	// Maximum attribute value
@@ -25,7 +25,7 @@ struct GMCABILITYSYSTEM_API FAttributeClamp
 
 	// Value will be clamped to the value of this attribute
 	// If set, this will take priority over Max
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"))
 	FGameplayTag MaxAttributeTag;
 
 	UPROPERTY()

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
@@ -1,0 +1,37 @@
+﻿#pragma once
+#include "GameplayTagContainer.h"
+#include "GMCAttributeClamp.generated.h"
+
+
+class UGMC_AbilitySystemComponent;
+
+USTRUCT()
+struct GMCABILITYSYSTEM_API FAttributeClamp
+{
+	GENERATED_BODY()
+
+	// Minimum attribute value
+	UPROPERTY(EditDefaultsOnly)
+	float Min;
+
+	// Value will be clamped to the value of this attribute
+	// If set, this will take priority over Min
+	UPROPERTY(EditDefaultsOnly)
+	FGameplayTag MinAttributeTag;
+
+	// Maximum attribute value
+	UPROPERTY(EditDefaultsOnly)
+	float Max;
+
+	// Value will be clamped to the value of this attribute
+	// If set, this will take priority over Max
+	UPROPERTY(EditDefaultsOnly)
+	FGameplayTag MaxAttributeTag;
+
+	UPROPERTY()
+	UGMC_AbilitySystemComponent* AbilityComponent;
+
+	bool operator==(const FAttributeClamp* Other) const {return Other->Min == Min && Other->Max == Max && Other->MinAttributeTag == MinAttributeTag && Other->MaxAttributeTag == MaxAttributeTag;}
+
+	float ClampValue(float Value) const;
+};

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifier.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifier.h
@@ -1,0 +1,35 @@
+﻿#pragma once
+#include "GMCAttributeModifier.generated.h"
+
+UENUM(BlueprintType)
+enum class EModifierType : uint8
+{
+	// Adds to value
+	Add,
+	// Adds to value multiplier. Base Multiplier is 1. A modifier value of 1 will double the value.
+	Multiply,
+	// Adds to value divisor. Base Divisor is 1. A modifier value of 1 will halve the value.
+	Divide     
+};
+
+USTRUCT(BlueprintType)
+struct FGMCAttributeModifier
+{
+	GENERATED_BODY()
+		
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="Attribute", meta = (Categories="Attribute"))
+	FGameplayTag AttributeTag;
+
+	// Value to modify the attribute by
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	float Value{0};
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	EModifierType ModifierType{EModifierType::Add};
+
+	// Metadata tags to be passed with the attribute
+	// Ie: DamageType (Element.Fire, Element.Electric), DamageSource (Source.Player, Source.Boss), etc
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	FGameplayTagContainer MetaTags;
+	
+};

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifier.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifier.h
@@ -1,4 +1,5 @@
 ﻿#pragma once
+#include "GameplayTags.h"
 #include "GMCAttributeModifier.generated.h"
 
 UENUM(BlueprintType)

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -2,10 +2,11 @@
 #include "GameplayTagContainer.h"
 #include "GMCAttributeClamp.h"
 #include "Effects/GMCAbilityEffect.h"
+#include "Net/Serialization/FastArraySerializer.h"
 #include "GMCAttributes.generated.h"
 
 USTRUCT(BlueprintType)
-struct GMCABILITYSYSTEM_API FAttribute
+struct GMCABILITYSYSTEM_API FAttribute : public FFastArraySerializerItem
 {
 	GENERATED_BODY()
 	FAttribute(){};
@@ -106,7 +107,8 @@ struct GMCABILITYSYSTEM_API FAttribute
 };
 
 USTRUCT()
-struct GMCABILITYSYSTEM_API FGMCAttributeSet{
+struct GMCABILITYSYSTEM_API FGMCAttributeSet : public FFastArraySerializer
+{
 	GENERATED_BODY()
 
 	UPROPERTY()
@@ -115,5 +117,30 @@ struct GMCABILITYSYSTEM_API FGMCAttributeSet{
 	void AddAttribute(FAttribute NewAttribute) {Attributes.Add(NewAttribute);}
 
 	TArray<FAttribute> GetAttributes() const{return Attributes;}
+
+	bool NetDeltaSerialize(FNetDeltaSerializeInfo & DeltaParms)
+	{
+		return FFastArraySerializer::FastArrayDeltaSerialize<FAttribute, FGMCAttributeSet>( Attributes, DeltaParms, *this );
+	}
+
+	void MarkAttributeDirtyByTag(FGameplayTag AttributeTag)
+	{
+		for (auto& Attribute : Attributes)
+		{
+			if (Attribute.Tag.MatchesTag(AttributeTag))
+			{
+				MarkItemDirty(Attribute);
+			}
+		}
+	}
+};
+
+template<>
+struct TStructOpsTypeTraits< FGMCAttributeSet > : public TStructOpsTypeTraitsBase2< FGMCAttributeSet >
+{
+	enum 
+	{
+		WithNetDeltaSerializer = true,
+   };
 };
 

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -79,6 +79,13 @@ struct GMCABILITYSYSTEM_API FAttribute
 		MultiplyModifier = 1;
 		DivisionModifier = 1;
 	}
+
+	// Allow for externally directly setting the BaseValue
+	// Usually preferred to go through Effects/Modifiers instead of this
+	void SetBaseValue(const float Value) const
+	{
+		BaseValue = Clamp.ClampValue(Value);
+	}
 	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	mutable float Value{0};

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -2,11 +2,10 @@
 #include "GameplayTagContainer.h"
 #include "GMCAttributeClamp.h"
 #include "Effects/GMCAbilityEffect.h"
-#include "Net/Serialization/FastArraySerializer.h"
 #include "GMCAttributes.generated.h"
 
 USTRUCT(BlueprintType)
-struct GMCABILITYSYSTEM_API FAttribute : public FFastArraySerializerItem
+struct GMCABILITYSYSTEM_API FAttribute
 {
 	GENERATED_BODY()
 	FAttribute(){};
@@ -107,8 +106,7 @@ struct GMCABILITYSYSTEM_API FAttribute : public FFastArraySerializerItem
 };
 
 USTRUCT()
-struct GMCABILITYSYSTEM_API FGMCAttributeSet : public FFastArraySerializer
-{
+struct GMCABILITYSYSTEM_API FGMCAttributeSet{
 	GENERATED_BODY()
 
 	UPROPERTY()
@@ -117,30 +115,5 @@ struct GMCABILITYSYSTEM_API FGMCAttributeSet : public FFastArraySerializer
 	void AddAttribute(FAttribute NewAttribute) {Attributes.Add(NewAttribute);}
 
 	TArray<FAttribute> GetAttributes() const{return Attributes;}
-
-	bool NetDeltaSerialize(FNetDeltaSerializeInfo & DeltaParms)
-	{
-		return FFastArraySerializer::FastArrayDeltaSerialize<FAttribute, FGMCAttributeSet>( Attributes, DeltaParms, *this );
-	}
-
-	void MarkAttributeDirtyByTag(FGameplayTag AttributeTag)
-	{
-		for (auto& Attribute : Attributes)
-		{
-			if (Attribute.Tag.MatchesTag(AttributeTag))
-			{
-				MarkItemDirty(Attribute);
-			}
-		}
-	}
-};
-
-template<>
-struct TStructOpsTypeTraits< FGMCAttributeSet > : public TStructOpsTypeTraitsBase2< FGMCAttributeSet >
-{
-	enum 
-	{
-		WithNetDeltaSerializer = true,
-   };
 };
 

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -82,9 +82,9 @@ struct GMCABILITYSYSTEM_API FAttribute
 
 	// Allow for externally directly setting the BaseValue
 	// Usually preferred to go through Effects/Modifiers instead of this
-	void SetBaseValue(const float Value) const
+	void SetBaseValue(const float NewValue) const
 	{
-		BaseValue = Clamp.ClampValue(Value);
+		BaseValue = Clamp.ClampValue(NewValue);
 	}
 	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -24,12 +24,12 @@ struct GMCABILITYSYSTEM_API FAttribute
 	UPROPERTY()
 	mutable float DivisionModifier{1};
 
-	void ApplyModifier(const FGMCAttributeModifier& Modifier) const
+	void ApplyModifier(const FGMCAttributeModifier& Modifier, bool bModifyBaseValue) const
 	{
 		switch(Modifier.ModifierType)
 		{
 		case EModifierType::Add:
-			if (Modifier.bApplyToBaseValue)
+			if (bModifyBaseValue)
 			{
 				BaseValue += Modifier.Value;
 				BaseValue = Clamp.ClampValue(BaseValue);

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 #include "GameplayTagContainer.h"
+#include "GMCAttributeClamp.h"
 #include "Effects/GMCAbilityEffect.h"
 #include "GMCAttributes.generated.h"
 
@@ -11,13 +12,12 @@ struct GMCABILITYSYSTEM_API FAttribute
 
 	void Init() const
 	{
-		CalculateValue();
+		CalculateValue(false);
 	}
 
-	// Starting Value of the attribute. Modifiers use this for calculations.
 	UPROPERTY()
 	mutable float AdditiveModifier{0};
-
+	
 	UPROPERTY()
 	mutable float MultiplyModifier{1};
 
@@ -29,7 +29,15 @@ struct GMCABILITYSYSTEM_API FAttribute
 		switch(Modifier.ModifierType)
 		{
 		case EModifierType::Add:
-			AdditiveModifier += Modifier.Value;
+			if (Modifier.bApplyToBaseValue)
+			{
+				BaseValue += Modifier.Value;
+				BaseValue = Clamp.ClampValue(BaseValue);
+			}
+			else
+			{
+				AdditiveModifier += Modifier.Value;
+			}
 			break;
 		case EModifierType::Multiply:
 			MultiplyModifier += Modifier.Value;
@@ -44,7 +52,7 @@ struct GMCABILITYSYSTEM_API FAttribute
 		CalculateValue();
 	}
 
-	void CalculateValue() const
+	void CalculateValue(bool bClamp = true) const
 	{
 		// Prevent divide by 0 and negative divisors
 		float LocalDivisionModifier = DivisionModifier;
@@ -58,13 +66,16 @@ struct GMCABILITYSYSTEM_API FAttribute
 			LocalMultiplyModifier = 0;
 		}
 		
-		Value = (AdditiveModifier + (BaseValue * LocalMultiplyModifier)) / LocalDivisionModifier;
+		Value =((BaseValue + AdditiveModifier) * LocalMultiplyModifier) / LocalDivisionModifier;
+		if (bClamp)
+		{
+			Value = Clamp.ClampValue(Value);
+		}
 	}
 
 	// Reset the modifiers to the base value. May cause jank if there's effects going on.
 	void ResetModifiers() const
 	{
-		AdditiveModifier = 0;
 		MultiplyModifier = 1;
 		DivisionModifier = 1;
 	}
@@ -83,6 +94,11 @@ struct GMCABILITYSYSTEM_API FAttribute
 	// NOTE: If you don't bind it, you can't use it for any kind of prediction.
 	UPROPERTY(EditDefaultsOnly)
 	bool bIsGMCBound = false;
+
+	// Clamp the attribute to a certain range
+	// Clamping will only happen if this is modified
+	UPROPERTY(EditDefaultsOnly)
+	FAttributeClamp Clamp{};
 
 	FString ToString() const{
 		return FString::Printf(TEXT("%s : %f (Bound: %d)"), *Tag.ToString(), Value, bIsGMCBound);

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributesData.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributesData.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "GameplayTagContainer.h"
 #include "Engine/DataAsset.h"
+#include "Attributes/GMCAttributeClamp.h"
 #include "GMCAttributesData.generated.h"
 
 /** Used only in the AttributesData Data Asset to instantiate attributes. */
@@ -18,6 +19,9 @@ struct FAttributeData{
 
 	UPROPERTY(EditDefaultsOnly)
 	float DefaultValue = 0.f;
+
+	UPROPERTY(EditDefaultsOnly)
+	FAttributeClamp Clamp;
 
 	/** Should the variable be bound to the GMC? If False, it will be replicated normally and CANNOT be used for
 	 * prediction. */

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -241,7 +241,7 @@ public:
 	
 	// Apply modifiers that affect attributes
 	UFUNCTION(BlueprintCallable, Category="GMAS|Attributes")
-	void ApplyAbilityEffectModifier(FGMCAttributeModifier AttributeModifier, bool bNegateValue = false, UGMC_AbilitySystemComponent* SourceAbilityComponent = nullptr);
+	void ApplyAbilityEffectModifier(FGMCAttributeModifier AttributeModifier,bool bModifyBaseValue, bool bNegateValue = false, UGMC_AbilitySystemComponent* SourceAbilityComponent = nullptr);
 
 	UPROPERTY(BlueprintReadWrite)
 	bool bJustTeleported;

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -6,6 +6,7 @@
 #include "GameplayTagContainer.h"
 #include "UObject/Object.h"
 #include "GMCAbilitySystem.h"
+#include "Attributes/GMCAttributeModifier.h"
 #include "GMCAbilityEffect.generated.h"
 
 class UGMC_AbilitySystemComponent;
@@ -24,45 +25,6 @@ enum class EEffectState : uint8
 	Initialized,  // Applies Instantly
 	Started, // Lasts for X time
 	Ended  // Lasts forever
-};
-
-UENUM(BlueprintType)
-enum class EModifierType : uint8
-{
-	// Adds to value
-	Add,
-	// Adds to value multiplier. Base Multiplier is 1. A modifier value of 1 will double the value.
-	Multiply,
-	// Adds to value divisor. Base Divisor is 1. A modifier value of 1 will halve the value.
-	Divide     
-};
-
-USTRUCT(BlueprintType)
-struct FGMCAttributeModifier
-{
-	GENERATED_BODY()
-		
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="Attribute", meta = (Categories="Attribute"))
-	FGameplayTag AttributeTag;
-
-	// Value to modify the attribute by
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
-	float Value{0};
-
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
-	EModifierType ModifierType{EModifierType::Add};
-
-	// Only affects Add modifiers
-	// Should this value directly modify the Attribute's BaseValue
-	// Set True for temporary effects, False for permanent effects
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
-	bool bApplyToBaseValue = false;
-
-	// Metadata tags to be passed with the attribute
-	// Ie: DamageType (Element.Fire, Element.Electric), DamageSource (Source.Player, Source.Boss), etc
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
-	FGameplayTagContainer MetaTags;
-	
 };
 
 // Container for exposing the attribute modifier to blueprints
@@ -109,9 +71,7 @@ struct FGMCAbilityEffectData
 	bool bIsInstant = true;
 
 	// Apply an inversed version of the modifiers at effect end
-	// Does not apply to Instant effects
-	// Won't work well for periodic effects or anything beyond simple effect modifications
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY()
 	bool bNegateEffectAtEnd = true;
 
 	// Delay before the effect starts

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -52,6 +52,12 @@ struct FGMCAttributeModifier
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
 	EModifierType ModifierType{EModifierType::Add};
 
+	// Only affects Add modifiers
+	// Should this value directly modify the Attribute's BaseValue
+	// Set True for temporary effects, False for permanent effects
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	bool bApplyToBaseValue = false;
+
 	// Metadata tags to be passed with the attribute
 	// Ie: DamageType (Element.Fire, Element.Electric), DamageSource (Source.Player, Source.Boss), etc
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -72,7 +72,7 @@ struct FGMCAbilityEffectData
 
 	// Apply an inversed version of the modifiers at effect end
 	UPROPERTY()
-	bool bNegateEffectAtEnd = true;
+	bool bNegateEffectAtEnd = false;
 
 	// Delay before the effect starts
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)


### PR DESCRIPTION
Core Change:

AttributeModifiers now have a `bApplyToBaseValue` flag:

```
	// Only affects Add modifiers
	// Should this value directly modify the Attribute's BaseValue
	// Set True for temporary effects, False for permanent effects
```

Applying to base value will directly modify the base value (duh :D). Otherwise it will use the Additive Modifier like how the old version does. For temporary effects, the effect will be (likely) be negated when the effect ends, or at some other point. For these kinds of effects, the total modifier is needed, as when the effect negates, it will subtract that value. This mostly matters when clamping (also in this PR).


--------

Some Examples of this in action:

### **Effect That Negates At End with bApplyToBaseValue=true (Wrong Usage, as effect is temporary and negates at end)**

CurrentAttributeValue: 100 (+0 Add modifier)
CurrentAttribute Value gets clamped to [0, 300]. 
Effect applies +500 modifier with `bApplyToBaseValue` as true

Result:
CurrentAttributeValue: 300 (+0 Add modifier)

Effect gets removed/negated. Result:
CurrentAttributeValue: 0 (+0 Add modifier)

### **Effect That Negates At End with bApplyToBaseValue=false (Correct Usage)**

CurrentAttributeValue: 100 (+0 Add modifier)
CurrentAttribute Value gets clamped to [0, 300]. 
Effect applies +500 modifier with `bApplyToBaseValue` as false

Result:
CurrentAttributeValue: 300 (+500 Add modifier)

Effect gets removed/negated. Result:
CurrentAttributeValue: 100 (+0 Add modifier)


This really matters for "Health" attributes, where most times you want to apply the value to the base and NOT the modifier. ie, if your max health is 100, you're at 75 health, and you get healed for 50 health, you Don't want "Value: 100, AddMod:+25", as subtracting from this value (taking damage) would use that +25 as a buffer. Health change is typically a permanent change, and should apply to BaseValue, so `bApplyToBaseValue` should be true.


-----

## Attribute Clamping

Clamping can now be set in the AttributeData. You can set raw floats for Min/Max, or optionally use existing Attribute tags. If the tag is set, that will take priority. 
Example:

Health: Min = 0, Max = Attribute.MaxHealth

This change required some changes in how attributes are initialized, mainly making sure they all initialize to their correct base values before trying to apply cross-attribute clamps.

If clamps aren't modified at all, they're not used at all (opt-in).

![image](https://github.com/reznok/GMCAbilitySystem/assets/23696484/be80c842-75ec-45b7-89dc-891aeaab6e7d)


Closes #46 

