### PR TITLE
move effect and cooldowns to ancillary tick, add ancillary tick options for abilities and tasks

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -31,12 +31,25 @@ void UGMCAbility::Tick(float DeltaTime)
 	TickEvent(DeltaTime);
 }
 
+void UGMCAbility::AncillaryTick(float DeltaTime){
+	AncillaryTickTasks(DeltaTime);
+	AncillaryTickEvent(DeltaTime);
+}
+
 void UGMCAbility::TickTasks(float DeltaTime)
 {
 	for (const TPair<int, UGMCAbilityTaskBase* >& Task : RunningTasks)
 	{
 		if (Task.Value == nullptr) {continue;}
 		Task.Value->Tick(DeltaTime);
+	}
+}
+
+void UGMCAbility::AncillaryTickTasks(float DeltaTime){
+	for (const TPair<int, UGMCAbilityTaskBase* >& Task : RunningTasks)
+	{
+		if (Task.Value == nullptr) {continue;}
+		Task.Value->AncillaryTick(DeltaTime);
 	}
 }
 

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/GMCAbilityTaskBase.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/GMCAbilityTaskBase.cpp
@@ -46,6 +46,10 @@ void UGMCAbilityTaskBase::Tick(float DeltaTime)
 
 }
 
+void UGMCAbilityTaskBase::AncillaryTick(float DeltaTime){
+	
+}
+
 void UGMCAbilityTaskBase::ClientProgressTask()
 {
 	FGMCAbilityTaskData TaskData;

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -54,14 +54,21 @@ public:
 
 	void RegisterTask(int Id, UGMCAbilityTaskBase* Task) {RunningTasks.Add(Id, Task);}
 	void TickTasks(float DeltaTime);
+	void AncillaryTickTasks(float DeltaTime);
 	
 	void Execute(UGMC_AbilitySystemComponent* InAbilityComponent, int InAbilityID, const UInputAction* InputAction = nullptr);
 	
-	// Called by AbilityComponent
+	// Called by AbilityComponent (this is a prediction tick so should be used for movement)
 	virtual void Tick(float DeltaTime);
+	
+	// Called by AbilityComponent from AncillaryTick (won't be rolled back on mispredictions)
+	virtual void AncillaryTick(float DeltaTime);
 	
 	UFUNCTION(BlueprintImplementableEvent, meta=(DisplayName="Tick Ability"), Category="GMCAbilitySystem|Ability")
 	void TickEvent(float DeltaTime);
+
+	UFUNCTION(BlueprintImplementableEvent, meta=(DisplayName="Ancillary Tick Ability"), Category="GMCAbilitySystem|Ability")
+	void AncillaryTickEvent(float DeltaTime);
 	
 	UFUNCTION()
 	virtual void BeginAbility();
@@ -164,6 +171,13 @@ public:
 	UPROPERTY(EditDefaultsOnly)
 	// Tags that the owner must not have to activate ability. BeginAbility will not be called if the owner has these tags.
 	FGameplayTagContainer ActivationBlockedTags;
+
+	/** 
+	 * If true, activate on movement tick, if false, activate on ancillary tick. Defaults to true.
+	 * Should be set to false for actions that should not be replayed on mispredictions. i.e. firing a weapon
+	 */
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	bool bActivateOnMovementTick = true; 
 
 	UFUNCTION()
 	void ServerConfirm();

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/GMCAbilityTaskBase.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/GMCAbilityTaskBase.h
@@ -39,6 +39,9 @@ public:
 	// Tick called by AbilityComponent, different from TickTask
 	virtual void Tick(float DeltaTime);
 
+	// AncillaryTick called by AbilityComponent, different from TickTask
+	virtual void AncillaryTick(float DeltaTime);
+
 	/** Helper function for instantiating and initializing a new task */
 	template <class T>
 	static T* NewAbilityTask(UGMCAbility* ThisAbility, FName InstanceName = FName())

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -122,7 +122,7 @@ public:
 	TArray<FGameplayTag> GetActiveTagsByParentTag(const FGameplayTag ParentTag);
 
 	// Do not call directly on client, go through QueueAbility
-	void TryActivateAbilitiesByInputTag(const FGameplayTag& InputTag, const UInputAction* InputAction = nullptr);
+	void TryActivateAbilitiesByInputTag(const FGameplayTag& InputTag, const UInputAction* InputAction = nullptr, bool bFromMovementTick=true);
 	
 	// Do not call directly on client, go through QueueAbility. Can be used to call server-side abilities (like AI).
 	bool TryActivateAbility(TSubclassOf<UGMCAbility> ActivatedAbility, const UInputAction* InputAction = nullptr);
@@ -403,6 +403,9 @@ private:
 
 	// Tick active abilities, primarily the Tasks inside them
 	void TickActiveAbilities(float DeltaTime);
+
+	// Tick active abilities, but from the ancillary tick rather than prediction
+	void TickAncillaryActiveAbilities(float DeltaTime);
 
 	// Tick ability cooldowns
 	void TickActiveCooldowns(float DeltaTime);


### PR DESCRIPTION
Basically I've moved the tick execution for effects and cooldowns to ancillary tick. I've also added the option for abilities to be activated on ancillary tick as well as a new tick event for abilities. Tasks are also given a new function that will tick from ancillary tick.