### PR TITLE
Minor fixes

### DIFF
--- a/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeClamp.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeClamp.cpp
@@ -3,10 +3,15 @@
 
 #include "GMCAbilityComponent.h"
 
+bool FAttributeClamp::IsSet() const
+{
+	return Min != 0.f || Max != 0.f || MinAttributeTag != FGameplayTag::EmptyTag || MaxAttributeTag != FGameplayTag::EmptyTag;
+}
+
 float FAttributeClamp::ClampValue(float Value) const
 {
 	// Clamp not set, return Value
-	if (this == FAttributeClamp{}){return Value;}
+	if (!IsSet()) {return Value;}
 
 	// No AbilityComponent, clamp to Min and Max
 	if (!AbilityComponent)

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
@@ -31,7 +31,10 @@ struct GMCABILITYSYSTEM_API FAttributeClamp
 	UPROPERTY()
 	UGMC_AbilitySystemComponent* AbilityComponent;
 
-	bool operator==(const FAttributeClamp* Other) const {return Other->Min == Min && Other->Max == Max && Other->MinAttributeTag == MinAttributeTag && Other->MaxAttributeTag == MaxAttributeTag;}
+	bool operator==(const FAttributeClamp* Other) const {return *this == *Other;} 
+	bool operator==(const FAttributeClamp& Other) const {return Other.Min == Min && Other.Max == Max && Other.MinAttributeTag == MinAttributeTag && Other.MaxAttributeTag == MaxAttributeTag;}
 
+	bool IsSet() const;
+	
 	float ClampValue(float Value) const;
 };

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -163,7 +163,7 @@ public:
 	
 	void UpdateState(EEffectState State, bool Force=false);
 
-	bool IsPeriodPaused();
+	virtual bool IsPeriodPaused();
 	
 	bool bCompleted;
 


### PR DESCRIPTION
Mostly this changeset fixes up attribute clamp slightly; it makes it possible to compare pointers and references for clamping, and adds an `IsSet()` to check whether or not clamp logic is set just to clean up `ClampValue()` slightly.

I also made `IsPeriodPaused` in effects virtual, to allow C++ effects to override it and provide more complex pause logic on periodic effects.