### PR TITLE
Attribute Replication Cleanup

### DIFF
--- a/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
+++ b/Source/GMCAbilitySystem/GMCAbilitySystem.Build.cs
@@ -18,7 +18,8 @@ public class GMCAbilitySystem : ModuleRules
 				"GameplayTasks",
 				"GameplayTags",
 				"GameplayDebugger",
-				"StructUtils"
+				"StructUtils",
+				"NetCore"
 				// ... add other public dependencies that you statically link with here ...
 			}
 			);

--- a/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeClamp.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeClamp.cpp
@@ -3,10 +3,15 @@
 
 #include "GMCAbilityComponent.h"
 
+bool FAttributeClamp::IsSet() const
+{
+	return Min != 0.f || Max != 0.f || MinAttributeTag != FGameplayTag::EmptyTag || MaxAttributeTag != FGameplayTag::EmptyTag;
+}
+
 float FAttributeClamp::ClampValue(float Value) const
 {
 	// Clamp not set, return Value
-	if (this == FAttributeClamp{}){return Value;}
+	if (!IsSet()) {return Value;}
 
 	// No AbilityComponent, clamp to Min and Max
 	if (!AbilityComponent)

--- a/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeClamp.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeClamp.cpp
@@ -1,5 +1,4 @@
-﻿#pragma once
-#include "Attributes/GMCAttributeClamp.h"
+﻿#include "Attributes/GMCAttributeClamp.h"
 
 #include "GMCAbilityComponent.h"
 

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -478,7 +478,9 @@ void UGMC_AbilitySystemComponent::InstantiateAttributes()
 			if(AttributeData.bGMCBound){
 				BoundAttributes.AddAttribute(NewAttribute);
 			}
-			else{
+			else if (GetOwnerRole() == ROLE_Authority) {
+				// FFastArraySerializer will duplicate all attributes on first replication if we
+				// add the attributes on the clients as well.
 				UnBoundAttributes.AddAttribute(NewAttribute);
 			}
 		}

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -11,8 +11,6 @@
 #include "Attributes/GMCAttributesData.h"
 #include "Effects/GMCAbilityEffect.h"
 #include "Net/UnrealNetwork.h"
-#include "WorldPartition/ContentBundle/ContentBundleLog.h"
-
 
 // Sets default values for this component's properties
 UGMC_AbilitySystemComponent::UGMC_AbilitySystemComponent(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
@@ -12,24 +12,24 @@ struct GMCABILITYSYSTEM_API FAttributeClamp
 
 	// Minimum attribute value
 	UPROPERTY(EditDefaultsOnly)
-	float Min;
+	float Min { 0.f };
 
 	// Value will be clamped to the value of this attribute
 	// If set, this will take priority over Min
 	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"))
-	FGameplayTag MinAttributeTag;
+	FGameplayTag MinAttributeTag { FGameplayTag::EmptyTag };
 
 	// Maximum attribute value
 	UPROPERTY(EditDefaultsOnly)
-	float Max;
+	float Max { 0.f };
 
 	// Value will be clamped to the value of this attribute
 	// If set, this will take priority over Max
 	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"))
-	FGameplayTag MaxAttributeTag;
+	FGameplayTag MaxAttributeTag { FGameplayTag::EmptyTag };
 
 	UPROPERTY()
-	UGMC_AbilitySystemComponent* AbilityComponent;
+	UGMC_AbilitySystemComponent* AbilityComponent { nullptr };
 
 	bool operator==(const FAttributeClamp* Other) const {return *this == *Other;} 
 	bool operator==(const FAttributeClamp& Other) const {return Other.Min == Min && Other.Max == Max && Other.MinAttributeTag == MinAttributeTag && Other.MaxAttributeTag == MaxAttributeTag;}

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
@@ -31,7 +31,10 @@ struct GMCABILITYSYSTEM_API FAttributeClamp
 	UPROPERTY()
 	UGMC_AbilitySystemComponent* AbilityComponent;
 
-	bool operator==(const FAttributeClamp* Other) const {return Other->Min == Min && Other->Max == Max && Other->MinAttributeTag == MinAttributeTag && Other->MaxAttributeTag == MaxAttributeTag;}
+	bool operator==(const FAttributeClamp* Other) const {return *this == *Other;} 
+	bool operator==(const FAttributeClamp& Other) const {return Other.Min == Min && Other.Max == Max && Other.MinAttributeTag == MinAttributeTag && Other.MaxAttributeTag == MaxAttributeTag;}
 
+	bool IsSet() const;
+	
 	float ClampValue(float Value) const;
 };

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -112,6 +112,11 @@ struct GMCABILITYSYSTEM_API FAttribute : public FFastArraySerializerItem
 	FString ToString() const{
 		return FString::Printf(TEXT("%s : %f (Bound: %d)"), *Tag.ToString(), Value, bIsGMCBound);
 	}
+
+	bool operator < (const FAttribute& Other) const
+	{
+		return Tag.ToString() < Other.Tag.ToString();
+	}
 };
 
 USTRUCT(BlueprintType)
@@ -121,9 +126,16 @@ struct GMCABILITYSYSTEM_API FGMCAttributeSet{
 	UPROPERTY()
 	TArray<FAttribute> Attributes;
 
-	void AddAttribute(const FAttribute& NewAttribute) {Attributes.Add(NewAttribute);}
+	void AddAttribute(const FAttribute& NewAttribute)
+	{
+		Attributes.Add(NewAttribute);
+		Attributes.Sort();
+	}
 
-	TArray<FAttribute> GetAttributes() const{return Attributes;}
+	TArray<FAttribute> GetAttributes() const
+	{
+		return Attributes;
+	}
 
 	void MarkAttributeDirty(const FAttribute& Attribute) {};
 };

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -158,7 +158,7 @@ public:
 
 	/** Struct containing attributes that are bound to the GMC */
 	UPROPERTY(BlueprintReadOnly, meta = (BaseStruct = "GMCAttributeSet"))
-	FInstancedStruct BoundAttributes;
+	FGMCAttributeSet BoundAttributes;
 
 	/** Struct containing attributes that are replicated and unbound from the GMC */
 	UPROPERTY(ReplicatedUsing = OnRep_UnBoundAttributes, BlueprintReadOnly, meta = (BaseStruct = "GMCAttributeSet"))

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -162,10 +162,10 @@ public:
 
 	/** Struct containing attributes that are replicated and unbound from the GMC */
 	UPROPERTY(ReplicatedUsing = OnRep_UnBoundAttributes, BlueprintReadOnly, meta = (BaseStruct = "GMCAttributeSet"))
-	FInstancedStruct UnBoundAttributes;
+	FGMCUnboundAttributeSet UnBoundAttributes;
 
 	UFUNCTION()
-	void OnRep_UnBoundAttributes(FInstancedStruct PreviousAttributes);
+	void OnRep_UnBoundAttributes(FGMCUnboundAttributeSet PreviousAttributes);
 
 	/**
 	 * Applies an effect to the Ability Component

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -157,11 +157,11 @@ public:
 	TArray<UGMCAttributesData*> AttributeDataAssets; 
 
 	/** Struct containing attributes that are bound to the GMC */
-	UPROPERTY(BlueprintReadOnly, meta = (BaseStruct = "GMCAttributeSet"))
+	UPROPERTY(BlueprintReadOnly)
 	FGMCAttributeSet BoundAttributes;
 
 	/** Struct containing attributes that are replicated and unbound from the GMC */
-	UPROPERTY(ReplicatedUsing = OnRep_UnBoundAttributes, BlueprintReadOnly, meta = (BaseStruct = "GMCAttributeSet"))
+	UPROPERTY(ReplicatedUsing = OnRep_UnBoundAttributes, BlueprintReadOnly)
 	FGMCUnboundAttributeSet UnBoundAttributes;
 
 	UFUNCTION()

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -163,7 +163,7 @@ public:
 	
 	void UpdateState(EEffectState State, bool Force=false);
 
-	bool IsPeriodPaused();
+	virtual bool IsPeriodPaused();
 	
 	bool bCompleted;
 


### PR DESCRIPTION
This PR alters attributes to be replicated more conservatively, so we're not just replicating the entire collection of attributes all at once.

* `FAttribute` now inherits `FFastArrayItem`.
* `FUnboundAttributeSet` now inherits `FFastArraySerializer` and thus will use delta updates to replicate attributes.
* The above change means that unbound attributes are _not_ created except on the authority, otherwise they get doubled on the first update from an `FFastArraySerializer`.
* `BoundAttributes` is no longer an instanced struct; it instead binds to the `Value`, `BaseValue`, and modifiers for each bound attribute, allowing those float values to be independently updated.
* Bound attributes are now sorted by attribute tag when instanciated, ensuring a consistent order for them for purposes of binding.

I've tested this PR in both my own game project and in the GMAS + GMCEx template project, and in both cases it works successfully. However, it would probably be best if one or both of you did a sanity-check pass and tried it in your own game as well!