### PR TITLE
Simple compability for engine compilation + crash fix

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -3,6 +3,8 @@
 #include "GMCPawn.h"
 #include "Ability/Tasks/GMCAbilityTaskBase.h"
 #include "Components/GMCAbilityComponent.h"
+#include "Logging/StructuredLog.h"
+
 
 UWorld* UGMCAbility::GetWorld() const
 {
@@ -110,9 +112,14 @@ void UGMCAbility::HandleTaskData(int TaskID, FInstancedStruct TaskData)
 
 void UGMCAbility::HandleTaskHeartbeat(int TaskID)
 {
-	if (RunningTasks.Contains(TaskID))
-	{
-		RunningTasks[TaskID]->Heartbeat();
+	if (RunningTasks.Contains(TaskID)) {
+		if (RunningTasks[TaskID]) {
+			RunningTasks[TaskID]->Heartbeat();
+		}
+		else {
+			RunningTasks.Remove(TaskID);
+			UE_LOGFMT(LogGMCAbilitySystem, Error, "Task with ID {ID} is nullptr", TaskID);
+		}
 	}
 }
 

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -28,17 +28,17 @@ class GMCABILITYSYSTEM_API UGMCAbility : public UObject, public IGameplayTaskOwn
 {
 	GENERATED_BODY()
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual UWorld* GetWorld() const override;
 	
 public:
 		//// Ability State
 	// EAbilityState. Use Getters/Setters
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	EAbilityState AbilityState;
 
 	// Data used to execute this ability
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	FGMCAbilityData AbilityData;
 
 	// Assign a new, incrementing, Task ID
@@ -94,55 +94,55 @@ public:
 	void SetOwnerJustTeleported(bool bValue);
 
 	// Tag to identify this ability. Required for setting cooldowns.
-	UPROPERTY(EditAnywhere, meta=(Categories="Ability"))
+	UPROPERTY(EditAnywhere, meta=(Categories="Ability"), Category = "GMCAbilitySystem")
 	FGameplayTag AbilityTag;
 
 	// An Effect that modifies attributes when the ability is activated
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	TSubclassOf<UGMCAbilityEffect> AbilityCost;
 
 	// How long in seconds ability should go on cooldown when activated
 	// Requires AbilityTag to be set
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	float CooldownTime;
 
 	// If true, the ability will apply the Cooldown when activated
 	// If false, the ability will NOT apply the Cooldown when the ability begins
 	// You can still apply the cooldown manually with CommitAbilityCooldown or CommitAbilityCostAndCooldown
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	bool bApplyCooldownAtAbilityBegin{true};
 
 	// Check to see if affected attributes in the AbilityCost would still be >= 0 after committing the cost
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	virtual bool CanAffordAbilityCost() const;
 
 	// Apply the effects in AbilityCost and (Re-)apply the CooldownTime of this ability
 	// Warning : Will apply CooldownTime regardless of already being on cooldown
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual void CommitAbilityCostAndCooldown();
 	
 	// (Re-)Apply the CooldownTime of this ability
 	// Warning : Will apply CooldownTime regardless of already being on cooldown
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual void CommitAbilityCooldown();
 	
 	// Apply the effects in AbilityCost
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual void CommitAbilityCost();
 
 	// Remove the ability cost effect (if applicable)
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual void RemoveAbilityCost();
 
 	// GMC_AbilitySystemComponent that owns this ability
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	UGMC_AbilitySystemComponent* OwnerAbilityComponent;
 
 	// The GMC Movement Component on the same actor as OwnerAbilityComponent
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	UGMC_MovementUtilityCmp* GetOwnerMovementComponent() const {return OwnerAbilityComponent->GMCMovementComponent; };
 	
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	TObjectPtr<const UInputAction> AbilityInputAction;
 
 	// Pass data into the Task
@@ -153,15 +153,15 @@ public:
 	// UFUNCTION(BlueprintCallable)
 	// bool HasAuthority();
 
-	UFUNCTION(BlueprintCallable, BlueprintPure)
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "GMCAbilitySystem")
 	bool AbilityEnded() {return AbilityState == EAbilityState::Ended;};
 
 	// Tags
 	// Tags that the owner must have to activate the ability. BeginAbility will not be called if the owner does not have these tags.
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	FGameplayTagContainer ActivationRequiredTags;
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	// Tags that the owner must not have to activate ability. BeginAbility will not be called if the owner has these tags.
 	FGameplayTagContainer ActivationBlockedTags;
 

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbilityData.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbilityData.h
@@ -20,12 +20,12 @@ struct FGMCAbilityData
 	int AbilityActivationID{0};
 	
 	// Ability ID to cast
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	FGameplayTag InputTag = FGameplayTag::EmptyTag;
 
 	// The input used to start the ability on the client
 	// Needed for things like "WaitForKeyRelease"
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	TObjectPtr<const UInputAction> ActionInput;
 
 	bool operator==(const FGMCAbilityData& Other) const { return AbilityActivationID == Other.AbilityActivationID && InputTag == Other.InputTag;}

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbilityMapData.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbilityMapData.h
@@ -17,15 +17,15 @@ struct FAbilityMapData{
 	GENERATED_BODY()
 
 	// Ability Tag
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	FGameplayTag InputTag;
 
 	// Ability Objects that the tag should execute
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	TArray<TSubclassOf<UGMCAbility>> Abilities;
 
 	// Whether or not this ability should be automatically granted to the owning Ability Component
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	bool bGrantedByDefault{true};
 };
 
@@ -33,7 +33,7 @@ UCLASS()
 class GMCABILITYSYSTEM_API UGMCAbilityMapData : public UPrimaryDataAsset{
 	GENERATED_BODY()
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	TArray<FAbilityMapData> AbilityMapData;
 
 public:

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataFloat.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataFloat.h
@@ -13,7 +13,7 @@ struct FGMCAbilityTaskTargetDataFloat : public FGMCAbilityTaskData
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	float Target{0};
 };
 
@@ -26,7 +26,7 @@ public:
 	UPROPERTY(BlueprintAssignable)
 	FUGMCAbilityTaskTargetDataFloatAsyncActionPin	Completed;
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	float Target;
 	
 	virtual void ProgressTask(FInstancedStruct& TaskData) override;

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataGameplayTag.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataGameplayTag.h
@@ -17,7 +17,7 @@ struct FGMCAbilityTaskTargetDataGameplayTag : public FGMCAbilityTaskData
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTag Target{FGameplayTag()};
 };
 
@@ -33,7 +33,7 @@ public:
 	UPROPERTY(BlueprintAssignable)
 	FUGMCAbilityTaskTargetDataGameplayTagAsyncActionPin	Completed;
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTag Target;
 	
 	virtual void ProgressTask(FInstancedStruct& TaskData) override;

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataInt.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataInt.h
@@ -13,7 +13,7 @@ struct FGMCAbilityTaskTargetDataInt : public FGMCAbilityTaskData
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	int Target{0};
 };
 
@@ -26,7 +26,7 @@ public:
 	UPROPERTY(BlueprintAssignable)
 	FUGMCAbilityTaskTargetDataIntAsyncActionPin	Completed;
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	int Target;
 	
 	virtual void ProgressTask(FInstancedStruct& TaskData) override;

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataVector3.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataVector3.h
@@ -13,7 +13,7 @@ struct FGMCAbilityTaskTargetDataVector3 : public FGMCAbilityTaskData
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FVector Target{FVector::Zero()};
 };
 
@@ -26,7 +26,7 @@ public:
 	UPROPERTY(BlueprintAssignable)
 	FUGMCAbilityTaskTargetDataVector3AsyncActionPin	Completed;
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FVector Target;
 	
 	virtual void ProgressTask(FInstancedStruct& TaskData) override;

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -69,10 +69,10 @@ struct GMCABILITYSYSTEM_API FAttribute
 		DivisionModifier = 1;
 	}
 	
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	mutable float Value{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	mutable float BaseValue{0};
 
 	// Attribute.* 
@@ -81,7 +81,7 @@ struct GMCABILITYSYSTEM_API FAttribute
 
 	// Whether this should be bound over GMC or not.
 	// NOTE: If you don't bind it, you can't use it for any kind of prediction.
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	bool bIsGMCBound = false;
 
 	FString ToString() const{

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributesData.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributesData.h
@@ -13,15 +13,15 @@ struct FAttributeData{
 	GENERATED_BODY()
 	
 	/** i.e. Attribute.Health */
-	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"))
+	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"), Category = "GMCAbilitySystem")
 	FGameplayTag AttributeTag;
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	float DefaultValue = 0.f;
 
 	/** Should the variable be bound to the GMC? If False, it will be replicated normally and CANNOT be used for
 	 * prediction. */
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	bool bGMCBound = true;
 };
 

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -53,7 +53,7 @@ public:
 	UGMC_AbilitySystemComponent(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
 
 	// Bound/Synced over GMC
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	double ActionTimer;
 
 	// Is this a server-only pawn (not player-controlled)?
@@ -75,50 +75,50 @@ public:
 	void RemoveAbilityMapData(UGMCAbilityMapData* AbilityMapData);
 		
 	// Add an ability to the GrantedAbilities array
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void GrantAbilityByTag(const FGameplayTag AbilityTag);
 
 	// Remove an ability from the GrantedAbilities array
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void RemoveGrantedAbilityByTag(const FGameplayTag AbilityTag);
 
-	UFUNCTION(BlueprintPure, meta=(Categories="Ability"))
+	UFUNCTION(BlueprintPure, meta=(Categories="Ability"), Category = "GMCAbilitySystem")
 	bool HasGrantedAbilityTag(const FGameplayTag GameplayTag) const;
 
 	// Add an ability to the GrantedAbilities array
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void AddActiveTag(const FGameplayTag AbilityTag);
 
 	// Remove an ability from the GrantedAbilities array
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void RemoveActiveTag(const FGameplayTag AbilityTag);
 
 	// Checks whether any active tag matches this tag or any of its children.
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasActiveTag(const FGameplayTag GameplayTag) const;
 
 	// Checks whether any active tag matches this tag exactly; it will not match on child tags.
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasActiveTagExact(const FGameplayTag GameplayTag) const;
 
 	// Checks whether any active tag matches any of the tags provided (or their children).
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasAnyTag(const FGameplayTagContainer TagsToCheck) const;
 
 	// Checks whether any active tag matches any of the tags provided exactly (excluding children).
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasAnyTagExact(const FGameplayTagContainer TagsToCheck) const;
 
 	// Checks whether every tag provided is in current tags, allowing for child tags.
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasAllTags(const FGameplayTagContainer TagsToCheck) const;
 
 	// Checks whether every tag provided is in current tags, without matching on child tags.
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasAllTagsExact(const FGameplayTagContainer TagsToCheck) const;
 	
 	/** Get all active tags that match a given parent tag */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	TArray<FGameplayTag> GetActiveTagsByParentTag(const FGameplayTag ParentTag);
 
 	// Do not call directly on client, go through QueueAbility
@@ -135,33 +135,33 @@ public:
 
 	// Set an ability cooldown
 	// If it's already on cooldown, subsequent calls will overwrite it
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void SetCooldownForAbility(const FGameplayTag AbilityTag, float CooldownTime);
 
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	float GetCooldownForAbility(const FGameplayTag AbilityTag) const;
 
 	// Get the cooldowns for all abilities associated with Input tag
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	TMap<FGameplayTag, float> GetCooldownsForInputTag(const FGameplayTag InputTag);
 	/**
 	 * Will add/remove a given gameplay tag to the ASC based on the bool inputted.
 	 * Call this function on Prediction Tick.
 	 * A good example of this is something like a State.InAir tag.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void MatchTagToBool(const FGameplayTag& InTag, bool MatchedBool);
 
 	// A UGMCAttributesData asset that defines the default attributes for this component
-	UPROPERTY(EditDefaultsOnly, DisplayName="Attributes")
+	UPROPERTY(EditDefaultsOnly, DisplayName="Attributes", Category = "GMCAbilitySystem")
 	TArray<UGMCAttributesData*> AttributeDataAssets; 
 
 	/** Struct containing attributes that are bound to the GMC */
-	UPROPERTY(BlueprintReadOnly, meta = (BaseStruct = "GMCAttributeSet"))
+	UPROPERTY(BlueprintReadOnly, meta = (BaseStruct = "GMCAttributeSet"), Category = "GMCAbilitySystem")
 	FInstancedStruct BoundAttributes;
 
 	/** Struct containing attributes that are replicated and unbound from the GMC */
-	UPROPERTY(ReplicatedUsing = OnRep_UnBoundAttributes, BlueprintReadOnly, meta = (BaseStruct = "GMCAttributeSet"))
+	UPROPERTY(ReplicatedUsing = OnRep_UnBoundAttributes, BlueprintReadOnly, meta = (BaseStruct = "GMCAttributeSet"), Category = "GMCAbilitySystem")
 	FInstancedStruct UnBoundAttributes;
 
 	UFUNCTION()
@@ -243,13 +243,13 @@ public:
 	UFUNCTION(BlueprintCallable, Category="GMAS|Attributes")
 	void ApplyAbilityEffectModifier(FGMCAttributeModifier AttributeModifier, bool bNegateValue = false, UGMC_AbilitySystemComponent* SourceAbilityComponent = nullptr);
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	bool bJustTeleported;
 
 	UFUNCTION(BlueprintCallable, Category="GMAS")
 	bool HasAuthority() const { return GetOwnerRole() == ROLE_Authority; }
 	
-	UPROPERTY(BlueprintReadWrite, AdvancedDisplay)
+	UPROPERTY(BlueprintReadWrite, AdvancedDisplay, Category = "GMCAbilitySystem", Category = "GMCAbilitySystem")
 	UGMC_MovementUtilityCmp* GMCMovementComponent;
 
 	UFUNCTION(Server, Reliable)

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -46,15 +46,15 @@ struct FGMCAttributeModifier
 	FGameplayTag AttributeTag;
 
 	// Value to modify the attribute by
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	float Value{0};
 
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	EModifierType ModifierType{EModifierType::Add};
 
 	// Metadata tags to be passed with the attribute
 	// Ie: DamageType (Element.Fire, Element.Electric), DamageSource (Source.Player, Source.Boss), etc
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer MetaTags;
 	
 };
@@ -66,7 +66,7 @@ class GMCABILITYSYSTEM_API UGMCAttributeModifierContainer : public UObject
 	GENERATED_BODY()
 	
 public:
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGMCAttributeModifier AttributeModifier;
 };
 
@@ -83,7 +83,7 @@ struct FGMCAbilityEffectData
 	{
 	}
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	UGMC_AbilitySystemComponent* SourceAbilityComponent;
 
 	UPROPERTY()
@@ -99,55 +99,55 @@ struct FGMCAbilityEffectData
 	double EndTime;
 
 	// Instantly applies effect then exits. Will not tick.
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	bool bIsInstant = true;
 
 	// Apply an inversed version of the modifiers at effect end
 	// Does not apply to Instant effects
 	// Won't work well for periodic effects or anything beyond simple effect modifications
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	bool bNegateEffectAtEnd = true;
 
 	// Delay before the effect starts
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	double Delay = 0;
 
 	// How long the effect lasts
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	double Duration = 0;
 
 	// How often the periodic effect ticks
 	// Suggest keeping this above .01
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	double Period = 0;
 
 	// For Period effects, whether first tick should happen immediately
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	bool bPeriodTickAtStart = false;
 
 	// Tag to identify this effect
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTag EffectTag;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer GrantedTags;
 
 	// Tags that the owner must have to apply and maintain this effect
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer MustHaveTags;
 
 	// Tags that the owner must not have to apply and maintain this effect
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer MustNotHaveTags;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer GrantedAbilities;
 
 	// If tag is present, periodic effect will not tick. Duration is not affected.
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer PausePeriodicEffect;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	TArray<FGMCAttributeModifier> Modifiers;
 	
 	inline bool operator==(const FGMCAbilityEffectData& Other) const
@@ -180,10 +180,10 @@ class GMCABILITYSYSTEM_API UGMCAbilityEffect : public UObject
 public:
 	EEffectState CurrentState;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	FGMCAbilityEffectData EffectData;
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void InitializeEffect(FGMCAbilityEffectData InitializationData);
 	
 	void EndEffect();
@@ -206,10 +206,10 @@ public:
 	float ClientEffectApplicationTime;
 
 protected:
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	UGMC_AbilitySystemComponent* SourceAbilityComponent;
 
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	UGMC_AbilitySystemComponent* OwnerAbilityComponent;
 
 private:

--- a/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
+++ b/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
@@ -26,16 +26,16 @@ struct GMCABILITYSYSTEM_API FGMCGameplayElementTagPropertyMapping
 		PropertyGuid = Other.PropertyGuid;
 	}
 	
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	FGameplayTagContainer TagsToMap;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category = "GMCAbilitySystem")
 	TFieldPath<FProperty> PropertyToMap;	
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category = "GMCAbilitySystem")
 	FName PropertyName;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category = "GMCAbilitySystem")
 	FGuid PropertyGuid;
 
 	FDelegateHandle DelegateHandle;
@@ -89,6 +89,6 @@ protected:
 	TWeakObjectPtr<UObject> CachedOwner;
 	TWeakObjectPtr<UGMC_AbilitySystemComponent> CachedAbilityComponent;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	TArray<FGMCGameplayElementTagPropertyMapping> PropertyMappings;
 };


### PR DESCRIPTION
- added the UPROPERTY Category to allow Plugin compilation with engine
- Fixed a crash in `HandleTaskHeartbeat` :
If you let a task live long enough, in case of a hitch or a low FPS, the task seem to be destroyed but keeped in the map `RunningTasks.` The check will avoid the crash, clean the list and throw a log message to avoid error shadowing in future développement. 
