### PR TITLE
Ensure abilities can be unique (one instance at a time).

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -260,6 +260,13 @@ bool UGMC_AbilitySystemComponent::TryActivateAbility(const TSubclassOf<UGMCAbili
 	// Also helps when dealing with replays
 	int AbilityID = GenerateAbilityID();
 
+	const UGMCAbility* AbilityCDO = ActivatedAbility->GetDefaultObject<UGMCAbility>();
+	if (!AbilityCDO->bAllowMultipleInstances)
+	{
+		// Enforce only one active instance of the ability at a time.
+		if (GetActiveAbilityCount(ActivatedAbility) > 0) return false;
+	}
+
 	// If multiple abilities are activated on the same frame, add 1 to the ID
 	// This should never actually happen as abilities get queued
 	while (ActiveAbilities.Contains(AbilityID)){
@@ -282,11 +289,46 @@ bool UGMC_AbilitySystemComponent::TryActivateAbility(const TSubclassOf<UGMCAbili
 void UGMC_AbilitySystemComponent::QueueAbility(FGameplayTag InputTag, const UInputAction* InputAction)
 {
 	if (GetOwnerRole() != ROLE_AutonomousProxy && GetOwnerRole() != ROLE_Authority) return;
-	
+
 	FGMCAbilityData Data;
 	Data.InputTag = InputTag;
 	Data.ActionInput = InputAction;
 	QueuedAbilities.Push(Data);
+}
+
+int32 UGMC_AbilitySystemComponent::GetQueuedAbilityCount(FGameplayTag AbilityTag)
+{
+	int32 Result = 0;
+
+	for (const auto& QueuedData : QueuedAbilities)
+	{
+		if (QueuedData.InputTag == AbilityTag) Result++;
+	}
+	return Result;
+}
+
+int32 UGMC_AbilitySystemComponent::GetActiveAbilityCount(TSubclassOf<UGMCAbility> AbilityClass)
+{
+	int32 Result = 0;
+
+	for (const auto& ActiveAbilityData : ActiveAbilities)
+	{
+		if (ActiveAbilityData.Value->IsA(AbilityClass)) Result++;
+	}
+
+	return Result;
+}
+
+int32 UGMC_AbilitySystemComponent::GetActiveAbilityCountByTag(FGameplayTag AbilityTag)
+{
+	int32 Result = 0;
+
+	for (const auto& Ability : GetGrantedAbilitiesByTag(AbilityTag))
+	{
+		Result += GetActiveAbilityCount(Ability);
+	}
+
+	return Result;
 }
 
 void UGMC_AbilitySystemComponent::QueueTaskData(const FInstancedStruct& InTaskData)
@@ -973,7 +1015,7 @@ FString UGMC_AbilitySystemComponent::GetActiveEffectsString() const{
 FString UGMC_AbilitySystemComponent::GetActiveAbilitiesString() const{
 	FString FinalString = TEXT("\n");
 	for(const TTuple<int, UGMCAbility*> ActiveAbility : ActiveAbilities){
-		FinalString += ActiveAbility.Value->ToString() + TEXT("\n");
+		FinalString += FString::Printf(TEXT("%d: "), ActiveAbility.Key) + ActiveAbility.Value->ToString() + TEXT("\n");
 	}
 	return FinalString;
 }

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -119,6 +119,11 @@ public:
 	UPROPERTY(EditAnywhere)
 	bool bApplyCooldownAtAbilityBegin{true};
 
+	// If true, more than one instance of this ability can be active at once. If false, the actual activation (but not
+	// the queuing) of an ability will fail if the ability already is active.
+	UPROPERTY(EditAnywhere)
+	bool bAllowMultipleInstances {false};
+	
 	// Check to see if affected attributes in the AbilityCost would still be >= 0 after committing the cost
 	UFUNCTION(BlueprintPure)
 	virtual bool CanAffordAbilityCost() const;

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -131,6 +131,15 @@ public:
 	UFUNCTION(BlueprintCallable, DisplayName="Activate Ability", Category="GMAS|Abilities")
 	void QueueAbility(UPARAM(meta=(Categories="Input"))FGameplayTag InputTag, const UInputAction* InputAction = nullptr);
 
+	UFUNCTION(BlueprintCallable, DisplayName="Count Queued Ability Instances", Category="GMAS|Abilities")
+	int32 GetQueuedAbilityCount(FGameplayTag AbilityTag);
+
+	UFUNCTION(BlueprintCallable, DisplayName="Count Activated Ability Instances", Category="GMAS|Abilities")
+	int32 GetActiveAbilityCount(TSubclassOf<UGMCAbility> AbilityClass);
+	
+	UFUNCTION(BlueprintCallable, DisplayName="Count Activated Ability Instances (by tag)", Category="GMAS|Abilities")
+	int32 GetActiveAbilityCountByTag(FGameplayTag AbilityTag);
+	
 	void QueueTaskData(const FInstancedStruct& TaskData);
 
 	// Set an ability cooldown


### PR DESCRIPTION
This adds functions to:

* Count the number of queued abilities matching a tag.
* Count the number of active abilities matching a tag or class.

This also adds a `bAllowMultipleInstances` setting to the base `GMCAbility`; if false, if an instance of the class is already active it will return false when calling `TryActivateAbility`.