### PR TITLE
Ability Precheck, Abilities Cancel by Tag, Check Before instances, Engine Plugin Compability

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -176,6 +176,18 @@ void UGMCAbility::OnGameplayTaskDeactivated(UGameplayTask& Task)
 	ActiveTasks.Remove(&Task);
 }
 
+
+void UGMCAbility::FinishEndAbility() {
+	for (const TPair<int, UGMCAbilityTaskBase* >& Task : RunningTasks)
+	{
+		if (Task.Value == nullptr) continue;
+		Task.Value->EndTaskGMAS();
+	}
+	
+	AbilityState = EAbilityState::Ended;
+}
+
+
 bool UGMCAbility::CheckActivationTags()
 {
 	// Required Tags
@@ -209,14 +221,14 @@ void UGMCAbility::BeginAbility()
 	// Check Activation Tags
 	if (!CheckActivationTags()){
 		UE_LOG(LogGMCAbilitySystem, Verbose, TEXT("Ability Activation for %s Stopped By Tags"), *AbilityTag.ToString());
-		EndAbility();
+		CancelAbility();
 		return;
 	}
 
 	if (IsOnCooldown())
 	{
 		UE_LOG(LogGMCAbilitySystem, Verbose, TEXT("Ability Activation for %s Stopped By Cooldown"), *AbilityTag.ToString());
-		EndAbility();
+		CancelAbility();
 		return;
 	}
 
@@ -234,15 +246,15 @@ void UGMCAbility::BeginAbility()
 
 void UGMCAbility::EndAbility()
 {
-	for (const TPair<int, UGMCAbilityTaskBase* >& Task : RunningTasks)
-	{
-		if (Task.Value == nullptr) continue;
-		Task.Value->EndTaskGMAS();
-	}
-	
-	AbilityState = EAbilityState::Ended;
+	FinishEndAbility();
 	EndAbilityEvent();
 }
+
+
+void UGMCAbility::CancelAbility() {
+	FinishEndAbility();
+}
+
 
 AActor* UGMCAbility::GetOwnerActor() const
 {

--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -188,29 +188,6 @@ void UGMCAbility::FinishEndAbility() {
 }
 
 
-bool UGMCAbility::CheckActivationTags()
-{
-	// Required Tags
-	for (const FGameplayTag Tag : ActivationRequiredTags)
-	{
-		if (!OwnerAbilityComponent->HasActiveTag(Tag))
-		{
-			return false;
-		}
-	}
-
-	// Blocking Tags
-	for (const FGameplayTag Tag : ActivationBlockedTags)
-	{
-		if (OwnerAbilityComponent->HasActiveTag(Tag))
-		{
-			return false;
-		}
-	}
-
-	return true;
-}
-
 bool UGMCAbility::IsOnCooldown() const
 {
 	return OwnerAbilityComponent->GetCooldownForAbility(AbilityTag) > 0;
@@ -218,13 +195,7 @@ bool UGMCAbility::IsOnCooldown() const
 
 void UGMCAbility::BeginAbility()
 {
-	// Check Activation Tags
-	if (!CheckActivationTags()){
-		UE_LOG(LogGMCAbilitySystem, Verbose, TEXT("Ability Activation for %s Stopped By Tags"), *AbilityTag.ToString());
-		CancelAbility();
-		return;
-	}
-
+	
 	if (IsOnCooldown())
 	{
 		UE_LOG(LogGMCAbilitySystem, Verbose, TEXT("Ability Activation for %s Stopped By Cooldown"), *AbilityTag.ToString());

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -351,6 +351,35 @@ int32 UGMC_AbilitySystemComponent::GetActiveAbilityCount(TSubclassOf<UGMCAbility
 	return Result;
 }
 
+
+int UGMC_AbilitySystemComponent::EndAbilitiesByTag(FGameplayTag AbilityTag) {
+	int AbilitiesEnded = 0;
+	for (const auto& ActiveAbilityData : ActiveAbilities)
+	{
+		if (ActiveAbilityData.Value->AbilityTag.MatchesTag(AbilityTag))
+		{
+			ActiveAbilityData.Value->EndAbility();
+			AbilitiesEnded++;
+		}
+	}
+	return AbilitiesEnded;
+}
+
+
+int UGMC_AbilitySystemComponent::EndAbilitiesByClass(TSubclassOf<UGMCAbility> AbilityClass) {
+	int AbilitiesEnded = 0;
+	for (const auto& ActiveAbilityData : ActiveAbilities)
+	{
+		if (ActiveAbilityData.Value->IsA(AbilityClass))
+		{
+			ActiveAbilityData.Value->EndAbility();
+			AbilitiesEnded++;
+		}
+	}
+	return AbilitiesEnded;
+}
+
+
 int32 UGMC_AbilitySystemComponent::GetActiveAbilityCountByTag(FGameplayTag AbilityTag)
 {
 	int32 Result = 0;

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -293,6 +293,12 @@ bool UGMC_AbilitySystemComponent::TryActivateAbility(const TSubclassOf<UGMCAbili
 		if (GetActiveAbilityCount(ActivatedAbility) > 0) return false;
 	}
 
+	// Check Activation Tags
+	if (!CheckActivationTags(AbilityCDO)){
+		UE_LOG(LogGMCAbilitySystem, Verbose, TEXT("Ability Activation for %s Stopped By Tags"), *GetNameSafe(ActivatedAbility));
+		return false;
+	}
+
 	// If multiple abilities are activated on the same frame, add 1 to the ID
 	// This should never actually happen as abilities get queued
 	while (ActiveAbilities.Contains(AbilityID)){
@@ -758,6 +764,34 @@ TArray<TSubclassOf<UGMCAbility>> UGMC_AbilitySystemComponent::GetGrantedAbilitie
 
 	return AbilityMap[AbilityTag].Abilities;
 }
+
+
+bool UGMC_AbilitySystemComponent::CheckActivationTags(const UGMCAbility* Ability) const {
+
+	if (!Ability) return false;
+
+	// Required Tags
+	for (const FGameplayTag Tag : Ability->ActivationBlockedTags)
+	{
+		if (!HasActiveTag(Tag))
+		{
+			return false;
+		}
+	}
+
+	// Blocking Tags
+	for (const FGameplayTag Tag : Ability->ActivationBlockedTags)
+	{
+		if (HasActiveTag(Tag))
+		{
+			return false;
+		}
+	}
+
+	return true;
+	
+}
+
 
 void UGMC_AbilitySystemComponent::InitializeAbilityMap(){
 	for (UGMCAbilityMapData* StartingAbilityMap : AbilityMaps)

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -79,6 +79,11 @@ public:
 	UFUNCTION(BlueprintCallable, meta=(DisplayName="End Ability"), Category="GMCAbilitySystem|Ability")
 	virtual void EndAbility();
 
+	/** End an ability without triggering the EndAbilityEvent.
+	 * This is useful for abilities that need to end immediately without any additional logic, usual for dead born abilities. */
+	UFUNCTION(BlueprintCallable, meta=(DisplayName="Cancel Ability"), Category="GMCAbilitySystem|Ability")
+	virtual void CancelAbility();
+
 	UFUNCTION(BlueprintImplementableEvent, meta=(DisplayName="End Ability"), Category="GMCAbilitySystem|Ability")
 	void EndAbilityEvent();
 
@@ -198,6 +203,8 @@ public:
 	virtual void OnGameplayTaskDeactivated(UGameplayTask& Task) override;
 	
 private:
+
+	void FinishEndAbility();
 
 	int AbilityID = -1;
 	int TaskIDCounter = -1;

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -69,6 +69,9 @@ public:
 
 	UFUNCTION(BlueprintImplementableEvent, meta=(DisplayName="Ancillary Tick Ability"), Category="GMCAbilitySystem|Ability")
 	void AncillaryTickEvent(float DeltaTime);
+
+	UFUNCTION(BlueprintNativeEvent, meta=(DisplayName="Ability PreExecution Check"), Category="GMCAbilitySystem|Ability")
+	bool PreExecuteCheckEvent();
 	
 	UFUNCTION()
 	virtual void BeginAbility();
@@ -181,6 +184,10 @@ public:
 	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	// Tags that the owner must not have to activate ability. BeginAbility will not be called if the owner has these tags.
 	FGameplayTagContainer ActivationBlockedTags;
+
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
+	// Cancel Abilities with these tags when this ability is activated
+	FGameplayTagContainer CancelAbilitiesWithTag;
 
 	/** 
 	 * If true, activate on movement tick, if false, activate on ancillary tick. Defaults to true.

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -28,17 +28,17 @@ class GMCABILITYSYSTEM_API UGMCAbility : public UObject, public IGameplayTaskOwn
 {
 	GENERATED_BODY()
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual UWorld* GetWorld() const override;
 	
 public:
 		//// Ability State
 	// EAbilityState. Use Getters/Setters
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	EAbilityState AbilityState;
 
 	// Data used to execute this ability
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	FGMCAbilityData AbilityData;
 
 	// Assign a new, incrementing, Task ID
@@ -101,60 +101,60 @@ public:
 	void SetOwnerJustTeleported(bool bValue);
 
 	// Tag to identify this ability. Required for setting cooldowns.
-	UPROPERTY(EditAnywhere, meta=(Categories="Ability"))
+	UPROPERTY(EditAnywhere, meta=(Categories="Ability"), Category = "GMCAbilitySystem")
 	FGameplayTag AbilityTag;
 
 	// An Effect that modifies attributes when the ability is activated
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	TSubclassOf<UGMCAbilityEffect> AbilityCost;
 
 	// How long in seconds ability should go on cooldown when activated
 	// Requires AbilityTag to be set
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	float CooldownTime;
 
 	// If true, the ability will apply the Cooldown when activated
 	// If false, the ability will NOT apply the Cooldown when the ability begins
 	// You can still apply the cooldown manually with CommitAbilityCooldown or CommitAbilityCostAndCooldown
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	bool bApplyCooldownAtAbilityBegin{true};
 
 	// If true, more than one instance of this ability can be active at once. If false, the actual activation (but not
 	// the queuing) of an ability will fail if the ability already is active.
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	bool bAllowMultipleInstances {false};
 	
 	// Check to see if affected attributes in the AbilityCost would still be >= 0 after committing the cost
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	virtual bool CanAffordAbilityCost() const;
 
 	// Apply the effects in AbilityCost and (Re-)apply the CooldownTime of this ability
 	// Warning : Will apply CooldownTime regardless of already being on cooldown
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual void CommitAbilityCostAndCooldown();
 	
 	// (Re-)Apply the CooldownTime of this ability
 	// Warning : Will apply CooldownTime regardless of already being on cooldown
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual void CommitAbilityCooldown();
 	
 	// Apply the effects in AbilityCost
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual void CommitAbilityCost();
 
 	// Remove the ability cost effect (if applicable)
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual void RemoveAbilityCost();
 
 	// GMC_AbilitySystemComponent that owns this ability
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	UGMC_AbilitySystemComponent* OwnerAbilityComponent;
 
 	// The GMC Movement Component on the same actor as OwnerAbilityComponent
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	UGMC_MovementUtilityCmp* GetOwnerMovementComponent() const {return OwnerAbilityComponent->GMCMovementComponent; };
 	
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	TObjectPtr<const UInputAction> AbilityInputAction;
 
 	// Pass data into the Task
@@ -165,15 +165,15 @@ public:
 	// UFUNCTION(BlueprintCallable)
 	// bool HasAuthority();
 
-	UFUNCTION(BlueprintCallable, BlueprintPure)
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "GMCAbilitySystem")
 	bool AbilityEnded() {return AbilityState == EAbilityState::Ended;};
 
 	// Tags
 	// Tags that the owner must have to activate the ability. BeginAbility will not be called if the owner does not have these tags.
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	FGameplayTagContainer ActivationRequiredTags;
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	// Tags that the owner must not have to activate ability. BeginAbility will not be called if the owner has these tags.
 	FGameplayTagContainer ActivationBlockedTags;
 
@@ -181,7 +181,7 @@ public:
 	 * If true, activate on movement tick, if false, activate on ancillary tick. Defaults to true.
 	 * Should be set to false for actions that should not be replayed on mispredictions. i.e. firing a weapon
 	 */
-	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "GMCAbilitySystem")
 	bool bActivateOnMovementTick = true; 
 
 	UFUNCTION()

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -220,8 +220,6 @@ private:
 	UPROPERTY()
 	TArray<TObjectPtr<UGameplayTask>> ActiveTasks;
 
-	bool CheckActivationTags();
-
 	UPROPERTY()
 	UGMCAbilityEffect* AbilityCostInstance = nullptr;
 

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbilityData.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbilityData.h
@@ -20,12 +20,12 @@ struct FGMCAbilityData
 	int AbilityActivationID{0};
 	
 	// Ability ID to cast
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	FGameplayTag InputTag = FGameplayTag::EmptyTag;
 
 	// The input used to start the ability on the client
 	// Needed for things like "WaitForKeyRelease"
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	TObjectPtr<const UInputAction> ActionInput;
 
 	bool operator==(const FGMCAbilityData& Other) const { return AbilityActivationID == Other.AbilityActivationID && InputTag == Other.InputTag;}

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbilityMapData.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbilityMapData.h
@@ -17,15 +17,15 @@ struct FAbilityMapData{
 	GENERATED_BODY()
 
 	// Ability Tag
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	FGameplayTag InputTag;
 
 	// Ability Objects that the tag should execute
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	TArray<TSubclassOf<UGMCAbility>> Abilities;
 
 	// Whether or not this ability should be automatically granted to the owning Ability Component
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	bool bGrantedByDefault{true};
 };
 
@@ -33,7 +33,7 @@ UCLASS()
 class GMCABILITYSYSTEM_API UGMCAbilityMapData : public UPrimaryDataAsset{
 	GENERATED_BODY()
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	TArray<FAbilityMapData> AbilityMapData;
 
 public:

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataFloat.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataFloat.h
@@ -13,7 +13,7 @@ struct FGMCAbilityTaskTargetDataFloat : public FGMCAbilityTaskData
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	float Target{0};
 };
 
@@ -26,7 +26,7 @@ public:
 	UPROPERTY(BlueprintAssignable)
 	FUGMCAbilityTaskTargetDataFloatAsyncActionPin	Completed;
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	float Target;
 	
 	virtual void ProgressTask(FInstancedStruct& TaskData) override;

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataGameplayTag.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataGameplayTag.h
@@ -17,7 +17,7 @@ struct FGMCAbilityTaskTargetDataGameplayTag : public FGMCAbilityTaskData
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTag Target{FGameplayTag()};
 };
 
@@ -33,7 +33,7 @@ public:
 	UPROPERTY(BlueprintAssignable)
 	FUGMCAbilityTaskTargetDataGameplayTagAsyncActionPin	Completed;
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTag Target;
 	
 	virtual void ProgressTask(FInstancedStruct& TaskData) override;

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataInt.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataInt.h
@@ -13,7 +13,7 @@ struct FGMCAbilityTaskTargetDataInt : public FGMCAbilityTaskData
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	int Target{0};
 };
 
@@ -26,7 +26,7 @@ public:
 	UPROPERTY(BlueprintAssignable)
 	FUGMCAbilityTaskTargetDataIntAsyncActionPin	Completed;
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	int Target;
 	
 	virtual void ProgressTask(FInstancedStruct& TaskData) override;

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataVector3.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/SetTargetDataVector3.h
@@ -13,7 +13,7 @@ struct FGMCAbilityTaskTargetDataVector3 : public FGMCAbilityTaskData
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FVector Target{FVector::Zero()};
 };
 
@@ -26,7 +26,7 @@ public:
 	UPROPERTY(BlueprintAssignable)
 	FUGMCAbilityTaskTargetDataVector3AsyncActionPin	Completed;
 	
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FVector Target;
 	
 	virtual void ProgressTask(FInstancedStruct& TaskData) override;

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeClamp.h
@@ -11,21 +11,21 @@ struct GMCABILITYSYSTEM_API FAttributeClamp
 	GENERATED_BODY()
 
 	// Minimum attribute value
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	float Min { 0.f };
 
 	// Value will be clamped to the value of this attribute
 	// If set, this will take priority over Min
-	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"))
+	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"), Category = "GMCAbilitySystem")
 	FGameplayTag MinAttributeTag { FGameplayTag::EmptyTag };
 
 	// Maximum attribute value
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	float Max { 0.f };
 
 	// Value will be clamped to the value of this attribute
 	// If set, this will take priority over Max
-	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"))
+	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"), Category = "GMCAbilitySystem")
 	FGameplayTag MaxAttributeTag { FGameplayTag::EmptyTag };
 
 	UPROPERTY()

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifier.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifier.h
@@ -22,15 +22,15 @@ struct FGMCAttributeModifier
 	FGameplayTag AttributeTag;
 
 	// Value to modify the attribute by
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	float Value{0};
 
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	EModifierType ModifierType{EModifierType::Add};
 
 	// Metadata tags to be passed with the attribute
 	// Ie: DamageType (Element.Fire, Element.Electric), DamageSource (Source.Player, Source.Boss), etc
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer MetaTags;
 	
 };

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -89,10 +89,10 @@ struct GMCABILITYSYSTEM_API FAttribute : public FFastArraySerializerItem
 		BaseValue = Clamp.ClampValue(NewValue);
 	}
 	
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	mutable float Value{0};
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	mutable float BaseValue{0};
 
 	// Attribute.* 
@@ -101,12 +101,12 @@ struct GMCABILITYSYSTEM_API FAttribute : public FFastArraySerializerItem
 
 	// Whether this should be bound over GMC or not.
 	// NOTE: If you don't bind it, you can't use it for any kind of prediction.
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	bool bIsGMCBound = false;
 
 	// Clamp the attribute to a certain range
 	// Clamping will only happen if this is modified
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	FAttributeClamp Clamp{};
 
 	FString ToString() const{

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributesData.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributesData.h
@@ -14,18 +14,18 @@ struct FAttributeData{
 	GENERATED_BODY()
 	
 	/** i.e. Attribute.Health */
-	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"))
+	UPROPERTY(EditDefaultsOnly, meta=(Categories="Attribute"), Category = "GMCAbilitySystem")
 	FGameplayTag AttributeTag;
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	float DefaultValue = 0.f;
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	FAttributeClamp Clamp;
 
 	/** Should the variable be bound to the GMC? If False, it will be replicated normally and CANNOT be used for
 	 * prediction. */
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
 	bool bGMCBound = true;
 };
 

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -137,7 +137,13 @@ public:
 	UFUNCTION(BlueprintCallable, DisplayName="Count Activated Ability Instances", Category="GMAS|Abilities")
 	int32 GetActiveAbilityCount(TSubclassOf<UGMCAbility> AbilityClass);
 
-	
+	UFUNCTION(BlueprintCallable, DisplayName="End Abilities (By Tag)", Category="GMAS|Abilities")
+	// End all abilities with the corresponding tag, returns the number of abilities ended
+	int EndAbilitiesByTag(FGameplayTag AbilityTag);
+
+	UFUNCTION(BlueprintCallable, DisplayName="End Abilities (By Class)", Category="GMAS|Abilities")
+	// End all abilities with the corresponding tag, returns the number of abilities ended
+	int EndAbilitiesByClass(TSubclassOf<UGMCAbility> AbilityClass);
 	
 	UFUNCTION(BlueprintCallable, DisplayName="Count Activated Ability Instances (by tag)", Category="GMAS|Abilities")
 	int32 GetActiveAbilityCountByTag(FGameplayTag AbilityTag);

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -136,6 +136,8 @@ public:
 
 	UFUNCTION(BlueprintCallable, DisplayName="Count Activated Ability Instances", Category="GMAS|Abilities")
 	int32 GetActiveAbilityCount(TSubclassOf<UGMCAbility> AbilityClass);
+
+	
 	
 	UFUNCTION(BlueprintCallable, DisplayName="Count Activated Ability Instances (by tag)", Category="GMAS|Abilities")
 	int32 GetActiveAbilityCountByTag(FGameplayTag AbilityTag);
@@ -353,6 +355,9 @@ protected:
 	FInstancedStruct TaskData = FInstancedStruct::Make(FGMCAbilityTaskData{});;
 
 private:
+
+	// return true if the ability is allowed to be activated considering active tags
+	bool CheckActivationTags(const UGMCAbility* Ability) const;
 
 	// Array of data objects to initialize the component's ability map
 	UPROPERTY(EditDefaultsOnly, Category="Ability")

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -53,7 +53,7 @@ public:
 	UGMC_AbilitySystemComponent(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
 
 	// Bound/Synced over GMC
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	double ActionTimer;
 
 	// Is this a server-only pawn (not player-controlled)?
@@ -75,50 +75,50 @@ public:
 	void RemoveAbilityMapData(UGMCAbilityMapData* AbilityMapData);
 		
 	// Add an ability to the GrantedAbilities array
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void GrantAbilityByTag(const FGameplayTag AbilityTag);
 
 	// Remove an ability from the GrantedAbilities array
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void RemoveGrantedAbilityByTag(const FGameplayTag AbilityTag);
 
-	UFUNCTION(BlueprintPure, meta=(Categories="Ability"))
+	UFUNCTION(BlueprintPure, meta=(Categories="Ability"), Category = "GMCAbilitySystem")
 	bool HasGrantedAbilityTag(const FGameplayTag GameplayTag) const;
 
 	// Add an ability to the GrantedAbilities array
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void AddActiveTag(const FGameplayTag AbilityTag);
 
 	// Remove an ability from the GrantedAbilities array
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void RemoveActiveTag(const FGameplayTag AbilityTag);
 
 	// Checks whether any active tag matches this tag or any of its children.
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasActiveTag(const FGameplayTag GameplayTag) const;
 
 	// Checks whether any active tag matches this tag exactly; it will not match on child tags.
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasActiveTagExact(const FGameplayTag GameplayTag) const;
 
 	// Checks whether any active tag matches any of the tags provided (or their children).
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasAnyTag(const FGameplayTagContainer TagsToCheck) const;
 
 	// Checks whether any active tag matches any of the tags provided exactly (excluding children).
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasAnyTagExact(const FGameplayTagContainer TagsToCheck) const;
 
 	// Checks whether every tag provided is in current tags, allowing for child tags.
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasAllTags(const FGameplayTagContainer TagsToCheck) const;
 
 	// Checks whether every tag provided is in current tags, without matching on child tags.
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	bool HasAllTagsExact(const FGameplayTagContainer TagsToCheck) const;
 	
 	/** Get all active tags that match a given parent tag */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	TArray<FGameplayTag> GetActiveTagsByParentTag(const FGameplayTag ParentTag);
 
 	// Do not call directly on client, go through QueueAbility
@@ -144,33 +144,33 @@ public:
 
 	// Set an ability cooldown
 	// If it's already on cooldown, subsequent calls will overwrite it
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void SetCooldownForAbility(const FGameplayTag AbilityTag, float CooldownTime);
 
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
 	float GetCooldownForAbility(const FGameplayTag AbilityTag) const;
 
 	// Get the cooldowns for all abilities associated with Input tag
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	TMap<FGameplayTag, float> GetCooldownsForInputTag(const FGameplayTag InputTag);
 	/**
 	 * Will add/remove a given gameplay tag to the ASC based on the bool inputted.
 	 * Call this function on Prediction Tick.
 	 * A good example of this is something like a State.InAir tag.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void MatchTagToBool(const FGameplayTag& InTag, bool MatchedBool);
 
 	// A UGMCAttributesData asset that defines the default attributes for this component
-	UPROPERTY(EditDefaultsOnly, DisplayName="Attributes")
+	UPROPERTY(EditDefaultsOnly, DisplayName="Attributes", Category = "GMCAbilitySystem")
 	TArray<UGMCAttributesData*> AttributeDataAssets; 
 
 	/** Struct containing attributes that are bound to the GMC */
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	FGMCAttributeSet BoundAttributes;
 
 	/** Struct containing attributes that are replicated and unbound from the GMC */
-	UPROPERTY(ReplicatedUsing = OnRep_UnBoundAttributes, BlueprintReadOnly)
+	UPROPERTY(ReplicatedUsing = OnRep_UnBoundAttributes, BlueprintReadOnly, Category = "GMCAbilitySystem")
 	FGMCUnboundAttributeSet UnBoundAttributes;
 
 	UFUNCTION()
@@ -252,13 +252,13 @@ public:
 	UFUNCTION(BlueprintCallable, Category="GMAS|Attributes")
 	void ApplyAbilityEffectModifier(FGMCAttributeModifier AttributeModifier,bool bModifyBaseValue, bool bNegateValue = false, UGMC_AbilitySystemComponent* SourceAbilityComponent = nullptr);
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	bool bJustTeleported;
 
 	UFUNCTION(BlueprintCallable, Category="GMAS")
 	bool HasAuthority() const { return GetOwnerRole() == ROLE_Authority; }
 	
-	UPROPERTY(BlueprintReadWrite, AdvancedDisplay)
+	UPROPERTY(BlueprintReadWrite, AdvancedDisplay, Category = "GMCAbilitySystem")
 	UGMC_MovementUtilityCmp* GMCMovementComponent;
 
 	UFUNCTION(Server, Reliable)

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -34,7 +34,7 @@ class GMCABILITYSYSTEM_API UGMCAttributeModifierContainer : public UObject
 	GENERATED_BODY()
 	
 public:
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGMCAttributeModifier AttributeModifier;
 };
 
@@ -51,7 +51,7 @@ struct FGMCAbilityEffectData
 	{
 	}
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite, Category = "GMCAbilitySystem")
 	UGMC_AbilitySystemComponent* SourceAbilityComponent;
 
 	UPROPERTY()
@@ -67,7 +67,7 @@ struct FGMCAbilityEffectData
 	double EndTime;
 
 	// Instantly applies effect then exits. Will not tick.
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	bool bIsInstant = true;
 
 	// Apply an inversed version of the modifiers at effect end
@@ -75,45 +75,45 @@ struct FGMCAbilityEffectData
 	bool bNegateEffectAtEnd = false;
 
 	// Delay before the effect starts
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	double Delay = 0;
 
 	// How long the effect lasts
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	double Duration = 0;
 
 	// How often the periodic effect ticks
 	// Suggest keeping this above .01
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	double Period = 0;
 
 	// For Period effects, whether first tick should happen immediately
-	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite)
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	bool bPeriodTickAtStart = false;
 
 	// Tag to identify this effect
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTag EffectTag;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer GrantedTags;
 
 	// Tags that the owner must have to apply and maintain this effect
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer MustHaveTags;
 
 	// Tags that the owner must not have to apply and maintain this effect
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer MustNotHaveTags;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer GrantedAbilities;
 
 	// If tag is present, periodic effect will not tick. Duration is not affected.
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer PausePeriodicEffect;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	TArray<FGMCAttributeModifier> Modifiers;
 	
 	inline bool operator==(const FGMCAbilityEffectData& Other) const
@@ -146,10 +146,10 @@ class GMCABILITYSYSTEM_API UGMCAbilityEffect : public UObject
 public:
 	EEffectState CurrentState;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	FGMCAbilityEffectData EffectData;
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void InitializeEffect(FGMCAbilityEffectData InitializationData);
 	
 	void EndEffect();
@@ -172,10 +172,10 @@ public:
 	float ClientEffectApplicationTime;
 
 protected:
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	UGMC_AbilitySystemComponent* SourceAbilityComponent;
 
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	UGMC_AbilitySystemComponent* OwnerAbilityComponent;
 
 private:

--- a/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
+++ b/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
@@ -26,16 +26,16 @@ struct GMCABILITYSYSTEM_API FGMCGameplayElementTagPropertyMapping
 		PropertyGuid = Other.PropertyGuid;
 	}
 	
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	FGameplayTagContainer TagsToMap;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category = "GMCAbilitySystem")
 	TFieldPath<FProperty> PropertyToMap;	
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category = "GMCAbilitySystem")
 	FName PropertyName;
 
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere, Category = "GMCAbilitySystem")
 	FGuid PropertyGuid;
 
 	FDelegateHandle DelegateHandle;
@@ -89,6 +89,6 @@ protected:
 	TWeakObjectPtr<UObject> CachedOwner;
 	TWeakObjectPtr<UGMC_AbilitySystemComponent> CachedAbilityComponent;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	TArray<FGMCGameplayElementTagPropertyMapping> PropertyMappings;
 };


### PR DESCRIPTION
- Adding Proper UPROPERTY Categories, this ensure the plugin is able to compile from source engine build (Please, don't forgot to add them in your UPROPERTY).
- Change in the `EndAbility` flow : 
  - Task termination and state is now done is an private method (`FinishEndAbility`)
  - Adding `CancelAbility`, purpose is the same of `EndAbility` at the difference it doesn't trigger `EndAbilityEvent`
  - The choice of splitting function is to ensure a better understand for end user on blueprint side (GAS Like)
- Check as `TagRequirements `are now done in `TryActivateAbility`, before the instanciation from the CDO.
- Adding `PreExecuteCheckEvent()` to allow end user to execute basic logic test like variable sanity check, and avoid ability execution if they fail (post instantiation)
- Adding Helpers `EndAbilitiesByTag`, and `EndAbilitiesByClass`
- Adding FGameplayTag Container `CancelAbilitiesWithTag`. It allow to End Active Ability with a tag (GAS-Like) on the start of a new ability (post-instantiation).
 