### PR TITLE
Add UGMCAbilityTask_WaitForInputKeyPress, fix some pointer misuse in UGMCAbilityTask_WaitForInputKeyRelease

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPress.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPress.cpp
@@ -1,0 +1,105 @@
+﻿// © Deep Worlds SA
+#include "Ability/Tasks/WaitForInputKeyPress.h"
+
+#include "EnhancedInputComponent.h"
+#include "SNegativeActionButton.h"
+#include "Components/GMCAbilityComponent.h"
+
+
+UGMCAbilityTask_WaitForInputKeyPress* UGMCAbilityTask_WaitForInputKeyPress::WaitForKeyPress(UGMCAbility* OwningAbility)
+{
+	UGMCAbilityTask_WaitForInputKeyPress* Task = NewAbilityTask<UGMCAbilityTask_WaitForInputKeyPress>(OwningAbility);
+	Task->Ability = OwningAbility;
+	return Task;
+}
+
+void UGMCAbilityTask_WaitForInputKeyPress::Activate()
+{
+	Super::Activate();
+
+	if (Ability->bAllowMultipleInstances) {
+		UE_LOG(LogGMCAbilitySystem, Warning, TEXT("Ability %s is set to allow multiple instances and this should not be used with WaitForInputKeyPress AbilityTask !"), *Ability->GetName());
+		ClientProgressTask();
+		return;
+	}
+	
+	if (Ability->AbilityInputAction != nullptr)
+	{
+		UEnhancedInputComponent* const InputComponent = GetEnhancedInputComponent();
+
+		const FEnhancedInputActionEventBinding& Binding = InputComponent->BindAction(
+			Ability->AbilityInputAction, ETriggerEvent::Started, this,
+			&UGMCAbilityTask_WaitForInputKeyPress::OnKeyPressed);
+		
+		InputBindingHandle = Binding.GetHandle();
+	}
+	else
+	{
+		ClientProgressTask();
+	}
+}
+
+void UGMCAbilityTask_WaitForInputKeyPress::OnKeyPressed(const FInputActionValue& InputActionValue)
+{
+	// Unbind from the input component so we don't fire multiple times.
+	if (UEnhancedInputComponent* InputComponent = GetValid(GetEnhancedInputComponent()))
+	{
+		InputComponent->RemoveActionBindingForHandle(InputBindingHandle);
+		InputBindingHandle = -1;
+	}
+
+	ClientProgressTask();
+}
+
+UEnhancedInputComponent* UGMCAbilityTask_WaitForInputKeyPress::GetEnhancedInputComponent() const
+{
+	UInputComponent* InputComponent = Ability->OwnerAbilityComponent->GetOwner()->GetComponentByClass<UInputComponent>();
+	if (InputComponent)
+	{
+		if (UEnhancedInputComponent* EnhancedInputComponent = CastChecked<UEnhancedInputComponent>(InputComponent))
+		{
+			return EnhancedInputComponent;
+		}
+	}
+	return nullptr;
+}
+
+void UGMCAbilityTask_WaitForInputKeyPress::OnTaskCompleted()
+{
+	EndTask();
+	Completed.Broadcast();
+	bTaskCompleted = true;
+}
+
+void UGMCAbilityTask_WaitForInputKeyPress::OnDestroy(bool bInOwnerFinished)
+{
+	Super::OnDestroy(bInOwnerFinished);
+
+	// If we're still bound to the input component for some reason, we'll want to unbind.
+	if (InputBindingHandle != -1)
+	{
+		if (UEnhancedInputComponent* InputComponent = GetValid(GetEnhancedInputComponent()))
+		{
+			InputComponent->RemoveActionBindingForHandle(InputBindingHandle);
+			InputBindingHandle = -1;
+		}
+	}
+}
+
+void UGMCAbilityTask_WaitForInputKeyPress::ProgressTask(FInstancedStruct& TaskData)
+{
+	Super::ProgressTask(TaskData);
+	OnTaskCompleted();
+}
+
+void UGMCAbilityTask_WaitForInputKeyPress::ClientProgressTask()
+{
+	FGMCAbilityTaskData TaskData;
+	TaskData.TaskType = EGMCAbilityTaskDataType::Progress;
+	TaskData.AbilityID = Ability->GetAbilityID();
+	TaskData.TaskID = TaskID;
+	const FInstancedStruct TaskDataInstance = FInstancedStruct::Make(TaskData);
+	
+	Ability->OwnerAbilityComponent->QueueTaskData(TaskDataInstance);
+}
+

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPress.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPress.cpp
@@ -1,10 +1,7 @@
-﻿// © Deep Worlds SA
-#include "Ability/Tasks/WaitForInputKeyPress.h"
+﻿#include "Ability/Tasks/WaitForInputKeyPress.h"
 
 #include "EnhancedInputComponent.h"
-#include "SNegativeActionButton.h"
 #include "Components/GMCAbilityComponent.h"
-
 
 UGMCAbilityTask_WaitForInputKeyPress* UGMCAbilityTask_WaitForInputKeyPress::WaitForKeyPress(UGMCAbility* OwningAbility)
 {

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyRelease.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyRelease.cpp
@@ -30,7 +30,7 @@ void UGMCAbilityTask_WaitForInputKeyRelease::Activate()
 		if (bShouldCheckForReleaseDuringActivation)
 		{
 			const FInputActionValue ActionValue = InputComponent->GetBoundActionValue(Ability->AbilityInputAction);
-			if (ActionValue.Get<bool>())
+			if (!ActionValue.Get<bool>())
 			{
 				// We'll want to immediately unbind the binding.
 				InputComponent->RemoveActionBindingForHandle(Binding.GetHandle());

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -28,11 +28,12 @@ class GMCABILITYSYSTEM_API UGMCAbility : public UObject, public IGameplayTaskOwn
 {
 	GENERATED_BODY()
 
+public:
+	
 	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual UWorld* GetWorld() const override;
 	
-public:
-		//// Ability State
+	//// Ability State
 	// EAbilityState. Use Getters/Setters
 	UPROPERTY(BlueprintReadOnly, Category = "GMCAbilitySystem")
 	EAbilityState AbilityState;

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/WaitForInputKeyPress.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/WaitForInputKeyPress.h
@@ -1,6 +1,4 @@
-﻿// © Deep Worlds SA
-
-#pragma once
+﻿#pragma once
 
 #include "CoreMinimal.h"
 #include "Ability/Tasks/GMCAbilityTaskBase.h"

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/WaitForInputKeyPress.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/WaitForInputKeyPress.h
@@ -1,0 +1,48 @@
+﻿// © Deep Worlds SA
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Ability/Tasks/GMCAbilityTaskBase.h"
+#include "EnhancedInputComponent.h"
+#include "Ability/GMCAbility.h"
+#include "InstancedStruct.h"
+#include "LatentActions.h"
+#include "WaitForInputKeyPress.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FAbilityTaskWaitForInputKeyPress);
+
+/**
+ * 
+ */
+UCLASS()
+class GMCABILITYSYSTEM_API UGMCAbilityTask_WaitForInputKeyPress : public UGMCAbilityTaskBase {
+	GENERATED_BODY()
+
+public:
+	
+	void OnTaskCompleted();
+	virtual void OnDestroy(bool bInOwnerFinished) override;
+
+	virtual void ProgressTask(FInstancedStruct& TaskData) override;
+	virtual void ClientProgressTask() override;
+	 
+	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", HidePin = "OwningAbility", DefaultToSelf = "OwningAbility", BlueprintInternalUseOnly = "TRUE"), DisplayName="Wait For Input Key Press",Category = "GMCAbilitySystem/Tasks")
+	static UGMCAbilityTask_WaitForInputKeyPress* WaitForKeyPress(UGMCAbility* OwningAbility);
+
+	//Overriding BP async action base
+	virtual void Activate() override;
+
+	UPROPERTY(BlueprintAssignable)
+	FAbilityTaskWaitForInputKeyPress Completed;
+
+protected:
+	
+	void OnKeyPressed(const FInputActionValue& InputActionValue);
+
+private:
+	
+	UEnhancedInputComponent* GetEnhancedInputComponent() const;
+
+	int64 InputBindingHandle = -1;
+};

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/WaitForInputKeyRelease.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/WaitForInputKeyRelease.h
@@ -15,29 +15,42 @@ class GMCABILITYSYSTEM_API UGMCAbilityTask_WaitForInputKeyRelease : public UGMCA
 	GENERATED_BODY()
 	
 public:
-
-	UFUNCTION()
-	virtual void Tick(float DeltaTime) override;
-
+	
 	void OnTaskCompleted();
 	virtual void OnDestroy(bool bInOwnerFinished) override;
 
 	virtual void ProgressTask(FInstancedStruct& TaskData) override;
 	virtual void ClientProgressTask() override;
-	 
+
+	/**
+	 * Creates a new ability task that will wait for the owning ability's input action key to be released.
+	 * @param OwningAbility The ability that owns this task.
+	 * @param bCheckForReleaseDuringActivation If true, we may complete this task during activation if the ability's input action key is already released.
+	 * @return 
+	 */
 	UFUNCTION(BlueprintCallable, meta = (BlueprintInternalUseOnly = "true", HidePin = "OwningAbility", DefaultToSelf = "OwningAbility", BlueprintInternalUseOnly = "TRUE"), DisplayName="Wait For Input Key Release",Category = "GMCAbilitySystem/Tasks")
-	static UGMCAbilityTask_WaitForInputKeyRelease* WaitForKeyRelease(UGMCAbility* OwningAbility);
- 
+	static UGMCAbilityTask_WaitForInputKeyRelease* WaitForKeyRelease(UGMCAbility* OwningAbility, bool bCheckForReleaseDuringActivation);
+
 	//Overriding BP async action base
 	virtual void Activate() override;
 
 	UPROPERTY(BlueprintAssignable)
 	FGMCAbilityTaskWaitForInputKeyRelease Completed;
 
+protected:
+
+	void OnKeyReleased(const FInputActionValue& InputActionValue);
+
+	/** If true, we may complete this task during activation if the ability's input action key is already released. */
+	UPROPERTY(Transient)
+	bool bShouldCheckForReleaseDuringActivation;
+
 private:
-	FEnhancedInputActionValueBinding* InputActionBinding;
+	
 	UEnhancedInputComponent* GetEnhancedInputComponent() const;
 
+	int64 InputBindingHandle = -1;
+	
 	// Todo: Add duration back in
 	float StartTime;
 	float Duration;


### PR DESCRIPTION
- Added `UGMCAbilityTask_WaitForInputKeyPress` which will wait for the ability's input action to be triggered to complete the task.
- Fixed `UGMCAbilityTask_WaitForInputKeyRelease` keeping a pointer to an element of the input component's action bindings array. In (semi-rare) cases, this pointer would end up pointing to wrong/invalid data and cause the task to never complete.
