### PR TITLE
Allow CheckActivationTags() to be overridden

### DIFF
--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -341,6 +341,9 @@ protected:
 	// Abilities that are granted to the player (bound)
 	FGameplayTagContainer GrantedAbilityTags;
 
+	// return true if the ability is allowed to be activated considering active tags
+	virtual bool CheckActivationTags(const UGMCAbility* Ability) const;
+
 	// Effect tags that are granted to the player (bound)
 	FGameplayTagContainer ActiveTags;
 
@@ -361,10 +364,6 @@ protected:
 	FInstancedStruct TaskData = FInstancedStruct::Make(FGMCAbilityTaskData{});;
 
 private:
-
-	// return true if the ability is allowed to be activated considering active tags
-	bool CheckActivationTags(const UGMCAbility* Ability) const;
-
 	// Array of data objects to initialize the component's ability map
 	UPROPERTY(EditDefaultsOnly, Category="Ability")
 	TArray<TObjectPtr<UGMCAbilityMapData>> AbilityMaps;


### PR DESCRIPTION
It's useful to have custom logic for checking tag requirements. For example Lyra uses the ULyraAbilityTagRelationshipMapping to describe tag relationships in a "central" data asset, rather than managing across individual abilities. See https://github.com/EpicGames/UnrealEngine/blob/release/Samples/Games/Lyra/Source/LyraGame/AbilitySystem/Abilities/LyraGameplayAbility.cpp#L315

This change would allow users to implement something like this.