### PR TITLE
Add attribute tags to various fields

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -73,7 +73,7 @@ bool UGMCAbility::CanAffordAbilityCost() const
 		{
 			if (Attribute->Tag.MatchesTagExact(AttributeModifier.AttributeTag))
 			{
-				if (Attribute->Value + AttributeModifier.Value < 0) return false;
+				if (Attribute->Value + AttributeModifier.GetValue(OwnerAbilityComponent) < 0) return false;
 			}
 		}
 	}
@@ -89,8 +89,9 @@ void UGMCAbility::CommitAbilityCostAndCooldown()
 
 void UGMCAbility::CommitAbilityCooldown()
 {
-	if (CooldownTime <= 0.f || OwnerAbilityComponent == nullptr) return;
-	OwnerAbilityComponent->SetCooldownForAbility(AbilityTag, CooldownTime);
+	float CalculatedCooldownTime = GetCooldownTime();
+	if (CalculatedCooldownTime <= 0.f || OwnerAbilityComponent == nullptr) return;
+	OwnerAbilityComponent->SetCooldownForAbility(AbilityTag, CalculatedCooldownTime);
 }
 
 void UGMCAbility::CommitAbilityCost()

--- a/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeModifier.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeModifier.cpp
@@ -1,0 +1,17 @@
+﻿#include "Attributes/GMCAttributeMOdifier.h"
+
+#include "GMCAbilityComponent.h"
+
+float FGMCAttributeModifier::GetValue(UGMC_AbilitySystemComponent* AbilityComponent) const
+{
+	// TODO: handle infinite recursion
+	
+	// Return value from attribute if AbilityComponent and ValueAttributeTag is valid
+	if (AbilityComponent && ValueAttributeTag.IsValid())
+	{
+		return AbilityComponent->GetAttributeValueByTag(ValueAttributeTag);
+	}
+
+	// Otherwise, fall back to the hard-coded value
+	return Value;
+}

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -1143,11 +1143,7 @@ void UGMC_AbilitySystemComponent::ApplyAbilityEffectModifier(FGMCAttributeModifi
 		if(!AffectedAttribute->bIsGMCBound && !HasAuthority()) return;
 		float OldValue = AffectedAttribute->Value;
 		
-		if (bNegateValue)
-		{
-			AttributeModifier.Value = -AttributeModifier.Value;
-		}
-		AffectedAttribute->ApplyModifier(AttributeModifier, bModifyBaseValue);
+		AffectedAttribute->ApplyModifier(this, AttributeModifier, bModifyBaseValue, bNegateValue);
 
 		OnAttributeChanged.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);
 		NativeAttributeChangeDelegate.Broadcast(AffectedAttribute->Tag, OldValue, AffectedAttribute->Value);

--- a/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
+++ b/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
@@ -6,6 +6,41 @@
 #include "GMCAbilitySystem.h"
 #include "Components/GMCAbilityComponent.h"
 
+float FGMCAbilityEffectData::GetDelay() const
+{
+	// Return value from attribute if DelayAttributeTag is valid
+	if (DelayAttributeTag.IsValid())
+	{
+		return OwnerAbilityComponent->GetAttributeValueByTag(DelayAttributeTag);
+	}
+
+	// Otherwise, fall back to the hard-coded value
+	return Delay;
+}
+
+float FGMCAbilityEffectData::GetDuration() const
+{
+	// Return value from attribute if DurationAttributeTag is valid
+	if (DurationAttributeTag.IsValid())
+	{
+		return OwnerAbilityComponent->GetAttributeValueByTag(DurationAttributeTag);
+	}
+
+	// Otherwise, fall back to the hard-coded value
+	return Duration;
+}
+
+float FGMCAbilityEffectData::GetPeriod() const
+{
+	// Return value from attribute if PeriodAttributeTag is valid
+	if (PeriodAttributeTag.IsValid())
+	{
+		return OwnerAbilityComponent->GetAttributeValueByTag(PeriodAttributeTag);
+	}
+
+	// Otherwise, fall back to the hard-coded value
+	return Period;
+}
 
 void UGMCAbilityEffect::InitializeEffect(FGMCAbilityEffectData InitializationData)
 {
@@ -30,7 +65,7 @@ void UGMCAbilityEffect::InitializeEffect(FGMCAbilityEffectData InitializationDat
 	}
 	else
 	{
-		EffectData.StartTime = OwnerAbilityComponent->ActionTimer + EffectData.Delay;
+		EffectData.StartTime = OwnerAbilityComponent->ActionTimer + EffectData.GetDelay();
 	}
 	
 	if (InitializationData.EndTime != 0)
@@ -39,11 +74,11 @@ void UGMCAbilityEffect::InitializeEffect(FGMCAbilityEffectData InitializationDat
 	}
 	else
 	{
-		EffectData.EndTime = EffectData.StartTime + EffectData.Duration;
+		EffectData.EndTime = EffectData.StartTime + EffectData.GetDuration();
 	}
 
 	// Start Immediately
-	if (EffectData.Delay == 0)
+	if (EffectData.GetDelay() == 0)
 	{
 		StartEffect();
 	}
@@ -77,7 +112,7 @@ void UGMCAbilityEffect::StartEffect()
 	}
 
 	// Duration Effects that aren't periodic alter modifiers, not base
-	if (!EffectData.bIsInstant && EffectData.Period == 0)
+	if (!EffectData.bIsInstant && EffectData.GetPeriod() == 0)
 	{
 		EffectData.bNegateEffectAtEnd = true;
 		for (const FGMCAttributeModifier& Modifier : EffectData.Modifiers)
@@ -87,7 +122,7 @@ void UGMCAbilityEffect::StartEffect()
 	}
 
 	// Tick period at start
-	if (EffectData.bPeriodTickAtStart && EffectData.Period > 0)
+	if (EffectData.bPeriodTickAtStart && EffectData.GetPeriod() > 0)
 	{
 		PeriodTick();
 	}
@@ -141,9 +176,9 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 
 
 	// If there's a period, check to see if it's time to tick
-	if (!IsPeriodPaused() && EffectData.Period > 0 && CurrentState == EEffectState::Started)
+	if (!IsPeriodPaused() && EffectData.GetPeriod() > 0 && CurrentState == EEffectState::Started)
 	{
-		const float Mod = FMath::Fmod(OwnerAbilityComponent->ActionTimer, EffectData.Period);
+		const float Mod = FMath::Fmod(OwnerAbilityComponent->ActionTimer, EffectData.GetPeriod());
 		if (Mod < PrevPeriodMod)
 		{
 			PeriodTick();
@@ -255,7 +290,7 @@ void UGMCAbilityEffect::CheckState()
 			}
 			break;
 		case EEffectState::Started:
-			if (EffectData.Duration != 0 && OwnerAbilityComponent->ActionTimer >= EffectData.EndTime)
+			if (EffectData.GetDuration() != 0 && OwnerAbilityComponent->ActionTimer >= EffectData.EndTime)
 			{
 				EndEffect();
 			}

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -125,6 +125,12 @@ public:
 	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
 	float CooldownTime;
 
+	// Instead of hard-coding a cooldown time, you can use another attribute to get the cooldown time from
+	// If set, this will take priority over CooldownTime
+	// Requires AbilityTag to be set
+	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
+	FGameplayTag CooldownTimeAttributeTag;
+
 	// If true, the ability will apply the Cooldown when activated
 	// If false, the ability will NOT apply the Cooldown when the ability begins
 	// You can still apply the cooldown manually with CommitAbilityCooldown or CommitAbilityCostAndCooldown
@@ -198,7 +204,19 @@ public:
 	 * Should be set to false for actions that should not be replayed on mispredictions. i.e. firing a weapon
 	 */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "GMCAbilitySystem")
-	bool bActivateOnMovementTick = true; 
+	bool bActivateOnMovementTick = true;
+
+	float GetCooldownTime() const
+	{
+		// Return value from attribute if set
+		if (CooldownTimeAttributeTag.IsValid())
+		{
+			return GetOwnerAttributeValueByTag(CooldownTimeAttributeTag);
+		}
+
+		// Otherwise, fall back to the hard-coded value
+		return CooldownTime;
+	}
 
 	UFUNCTION()
 	void ServerConfirm();

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifier.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributeModifier.h
@@ -2,6 +2,8 @@
 #include "GameplayTags.h"
 #include "GMCAttributeModifier.generated.h"
 
+class UGMC_AbilitySystemComponent;
+
 UENUM(BlueprintType)
 enum class EModifierType : uint8
 {
@@ -17,7 +19,8 @@ USTRUCT(BlueprintType)
 struct FGMCAttributeModifier
 {
 	GENERATED_BODY()
-		
+
+	// Attribute to apply modifier to
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="Attribute", meta = (Categories="Attribute"))
 	FGameplayTag AttributeTag;
 
@@ -25,6 +28,12 @@ struct FGMCAttributeModifier
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	float Value{0};
 
+	// Instead of hard-coding a value, you can use another attribute to get the value from
+	// If set, this will take priority over Value
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category="GMCAbilitySystem", meta = (Categories="Attribute"))
+	FGameplayTag ValueAttributeTag;
+
+	// Type of modifier to apply
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	EModifierType ModifierType{EModifierType::Add};
 
@@ -32,5 +41,6 @@ struct FGMCAttributeModifier
 	// Ie: DamageType (Element.Fire, Element.Electric), DamageSource (Source.Player, Source.Boss), etc
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer MetaTags;
-	
+
+	float GetValue(UGMC_AbilitySystemComponent* AbilityComponent) const;
 };

--- a/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
+++ b/Source/GMCAbilitySystem/Public/Attributes/GMCAttributes.h
@@ -25,26 +25,32 @@ struct GMCABILITYSYSTEM_API FAttribute : public FFastArraySerializerItem
 	UPROPERTY()
 	mutable float DivisionModifier{1};
 
-	void ApplyModifier(const FGMCAttributeModifier& Modifier, bool bModifyBaseValue) const
+	void ApplyModifier(UGMC_AbilitySystemComponent* AbilityComponent, const FGMCAttributeModifier& Modifier, bool bModifyBaseValue, bool bNegateValue) const
 	{
+		float ModifierValue = Modifier.GetValue(AbilityComponent);
+		if (bNegateValue)
+		{
+			ModifierValue = -ModifierValue;
+		}
+		
 		switch(Modifier.ModifierType)
 		{
 		case EModifierType::Add:
 			if (bModifyBaseValue)
 			{
-				BaseValue += Modifier.Value;
+				BaseValue += ModifierValue;
 				BaseValue = Clamp.ClampValue(BaseValue);
 			}
 			else
 			{
-				AdditiveModifier += Modifier.Value;
+				AdditiveModifier += ModifierValue;
 			}
 			break;
 		case EModifierType::Multiply:
-			MultiplyModifier += Modifier.Value;
+			MultiplyModifier += ModifierValue;
 			break;
 		case EModifierType::Divide:
-			DivisionModifier += Modifier.Value;
+			DivisionModifier += ModifierValue;
 			break;
 		default:
 			break;

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -74,18 +74,33 @@ struct FGMCAbilityEffectData
 	UPROPERTY()
 	bool bNegateEffectAtEnd = false;
 
-	// Delay before the effect starts
+	// Delay before the effect starts (in seconds)
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	double Delay = 0;
 
-	// How long the effect lasts
+	// Instead of hard-coding a delay, you can use another attribute to get the value from
+	// If set, this will take priority over Delay
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
+	FGameplayTag DelayAttributeTag;
+
+	// How long the effect lasts (in seconds)
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	double Duration = 0;
 
-	// How often the periodic effect ticks
+	// Instead of hard-coding a duration, you can use another attribute to get the value from
+	// If set, this will take priority over Duration
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
+	FGameplayTag DurationAttributeTag;
+
+	// How often the periodic effect ticks (in seconds)
 	// Suggest keeping this above .01
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	double Period = 0;
+
+	// Instead of hard-coding a period, you can use another attribute to get the value from
+	// If set, this will take priority over Period
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
+	FGameplayTag PeriodAttributeTag;
 
 	// For Period effects, whether first tick should happen immediately
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "GMCAbilitySystem")
@@ -129,8 +144,12 @@ struct FGMCAbilityEffectData
 	}
 
 	FString ToString() const{
-		return FString::Printf(TEXT("[id: %d] [Tag: %s] (Duration: %f)"), EffectID, *EffectTag.ToString(), Duration);
+		return FString::Printf(TEXT("[id: %d] [Tag: %s] (Duration: %f)"), EffectID, *EffectTag.ToString(), GetDuration());
 	}
+
+	float GetDelay() const;
+	float GetDuration() const;
+	float GetPeriod() const;
 };
 
 /**


### PR DESCRIPTION
#78 

I think it would be helpful if we could specify attribute tags for various hardcoded values in GMAS. I'm working on a proof of concept, but I'm curious if there's any technical or design blockers for this feature. I'm also super new to this project, so please let me know if there are better intended solutions for these use cases.

Here's some examples:

## Effect Delay, Duration, Period
Example use cases:
* Declare an effect that grants a player a running speed boost. Attribute allows duration to be made longer or shorter
* Declare an effect that increases weapon ammunition by 1 (e.g. reload a shotgun). Attribute allows reload speed to be modified

Possible Issues:
* adds a lot of fields in the effect data
![image](https://github.com/reznok/GMCAbilitySystem/assets/9141989/69c6982b-7a9a-49d6-8fa5-9d6c6d681607)
* if duration, delay, or period change, we may want to update the end time for the effect

## Effect Modifier Value
Example use cases:
* Declare an effect that recharges stamina over time. Create an attribute tag for stamina recharge speed and use that as the value for the recharge effect. Attribute allows modifying stamina recharge speed
* Declare an effect that does fire damage to a player over time. Create an attribute tag representing the damage for the effect. Attribute allows modifying fire damage on player (e.g. fire resistance)

Possible Issues:
* May be confusing to users, as there are two attribute tags that can be configured
* Can run into issues with infinite recursion if there is a loop attributes referencing each other via modifiers


## Cooldown Time
Example use cases:
* Create an ability that allows the player to jump. When the player lands, the effect completes. When the effect completes, commit the cooldown. Attribute allows the cooldown duration between jumps to vary

Possible Issues:
* If the cooldown time changes, we may want to update the end time for the cooldown