### PR TITLE
Add methods to add/remove starting effects

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -196,6 +196,22 @@ void UGMC_AbilitySystemComponent::RemoveAbilityMapData(UGMCAbilityMapData* Abili
 	}
 }
 
+void UGMC_AbilitySystemComponent::AddStartingEffects(TArray<TSubclassOf<UGMCAbilityEffect>> EffectsToAdd)
+{
+	for (const TSubclassOf<UGMCAbilityEffect> Effect : EffectsToAdd)
+	{
+		StartingEffects.AddUnique(Effect);
+	}
+}
+
+void UGMC_AbilitySystemComponent::RemoveStartingEffects(TArray<TSubclassOf<UGMCAbilityEffect>> EffectsToRemove)
+{
+	for (const TSubclassOf<UGMCAbilityEffect> Effect : EffectsToRemove)
+	{
+		StartingEffects.Remove(Effect);
+	}
+}
+
 void UGMC_AbilitySystemComponent::GrantAbilityByTag(const FGameplayTag AbilityTag)
 {
 	if (!GrantedAbilityTags.HasTagExact(AbilityTag))

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -73,7 +73,13 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category="GMAS|Abilities")
 	void RemoveAbilityMapData(UGMCAbilityMapData* AbilityMapData);
-		
+
+	UFUNCTION(BlueprintCallable, Category="GMAS|Abilities")
+	void AddStartingEffects(TArray<TSubclassOf<UGMCAbilityEffect>> EffectsToAdd);
+
+	UFUNCTION(BlueprintCallable, Category="GMAS|Abilities")
+	void RemoveStartingEffects(TArray<TSubclassOf<UGMCAbilityEffect>> EffectsToRemove);
+
 	// Add an ability to the GrantedAbilities array
 	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void GrantAbilityByTag(const FGameplayTag AbilityTag);


### PR DESCRIPTION
These methods are useful during character initialization as a way to support customization of starting effects at runtime. I'm specifically using this to support module game features which can add/remove effects depending on which game features are loaded.