### PR TITLE
Minor Cleanup

### DIFF
--- a/Source/GMCAbilitySystem/Private/Animation/GMCAbilityAnimInstance.cpp
+++ b/Source/GMCAbilitySystem/Private/Animation/GMCAbilityAnimInstance.cpp
@@ -11,6 +11,11 @@ UGMCAbilityAnimInstance::UGMCAbilityAnimInstance(const FObjectInitializer& Objec
 #endif
 }
 
+UGMCAbilityAnimInstance::~UGMCAbilityAnimInstance()
+{
+ 	TagPropertyMap.Reset();
+}
+
 void UGMCAbilityAnimInstance::NativeInitializeAnimation()
 {
 	Super::NativeInitializeAnimation();

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -574,6 +574,7 @@ void UGMC_AbilitySystemComponent::InstantiateAttributes()
 	{
 		Attribute.CalculateValue();
 	}
+	UnBoundAttributes.MarkArrayDirty();
 }
 
 void UGMC_AbilitySystemComponent::SetStartingTags()

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -586,6 +586,7 @@ void UGMC_AbilitySystemComponent::InstantiateAttributes()
 		Attribute.CalculateValue();
 		UnBoundAttributes.MarkItemDirty(Attribute);
 	}
+	UnBoundAttributes.MarkArrayDirty();
 }
 
 void UGMC_AbilitySystemComponent::SetStartingTags()

--- a/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
+++ b/Source/GMCAbilitySystem/Public/Animation/GMCAbilityAnimInstance.h
@@ -19,6 +19,7 @@ class GMCABILITYSYSTEM_API UGMCAbilityAnimInstance : public UAnimInstance
 
 public:
 	UGMCAbilityAnimInstance(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
+	virtual ~UGMCAbilityAnimInstance();
 	
 	virtual void NativeBeginPlay() override;
 	virtual void NativeInitializeAnimation() override;

--- a/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
+++ b/Source/GMCAbilitySystem/Public/Utility/GameplayElementMapping.h
@@ -60,6 +60,8 @@ public:
 
 	// Must be called to actually start using this instance.
 	void Initialize(UObject* Owner, UGMC_AbilitySystemComponent* AbilitySystemComponent);
+	void Unregister();
+	void Reset();
 
 	void ApplyCurrentTags();
 	void ApplyCurrentAttributes();
@@ -76,8 +78,6 @@ protected:
 	bool SetValueForMappedProperty(FProperty* Property, float PropValue);
 	bool SetValueForMappedProperty(FProperty* Property, FGameplayTagContainer& MatchedTags);
 	
-	void Unregister();
-
 	void GameplayTagChangedCallback(const FGameplayTagContainer& AddedTags, const FGameplayTagContainer& RemovedTags);
 
 	void GameplayAttributeChangedCallback(const FGameplayTag& AttributeTag, const float OldValue, const float NewValue);


### PR DESCRIPTION
* Ensure clean setup of unbound attributes in all scenarios.
* Ensure attribute changes only generate callbacks if the value actually changed.
* Handle the GMAS animation blueprint base being used as a child layer as well.