### PR TITLE
Display selected actor's GMAS data in debugger

### DIFF
--- a/Source/GMCAbilitySystem/Private/Debug/GameplayDebuggerCategory_GMCAbilitySystem.cpp
+++ b/Source/GMCAbilitySystem/Private/Debug/GameplayDebuggerCategory_GMCAbilitySystem.cpp
@@ -15,25 +15,18 @@ FGameplayDebuggerCategory_GMCAbilitySystem::FGameplayDebuggerCategory_GMCAbility
 
 void FGameplayDebuggerCategory_GMCAbilitySystem::CollectData(APlayerController* OwnerPC, AActor* DebugActor)
 {
-	if (OwnerPC)
+	if (DebugActor)
 	{
-		if (OwnerPC->GetPawn())
-		{
-			DataPack.ActorName = OwnerPC->GetPawn()->GetName();
+		DataPack.ActorName = DebugActor->GetName();
 
-			if (const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>())
-			{
-				DataPack.GrantedAbilities = AbilityComponent->GetGrantedAbilities().ToStringSimple();
-				DataPack.ActiveTags = AbilityComponent->GetActiveTags().ToStringSimple();
-				DataPack.Attributes = AbilityComponent->GetAllAttributesString();
-				DataPack.ActiveEffects = AbilityComponent->GetActiveEffectsString();
-				DataPack.ActiveEffectData = AbilityComponent->GetActiveEffectsDataString();
-				DataPack.ActiveAbilities = AbilityComponent->GetActiveAbilitiesString();
-			}
-		}
-		else
+		if (const UGMC_AbilitySystemComponent* AbilityComponent = DebugActor->FindComponentByClass<UGMC_AbilitySystemComponent>())
 		{
-			DataPack.ActorName = TEXT("Spectator or missing pawn");
+			DataPack.GrantedAbilities = AbilityComponent->GetGrantedAbilities().ToStringSimple();
+			DataPack.ActiveTags = AbilityComponent->GetActiveTags().ToStringSimple();
+			DataPack.Attributes = AbilityComponent->GetAllAttributesString();
+			DataPack.ActiveEffects = AbilityComponent->GetActiveEffectsString();
+			DataPack.ActiveEffectData = AbilityComponent->GetActiveEffectsDataString();
+			DataPack.ActiveAbilities = AbilityComponent->GetActiveAbilitiesString();
 		}
 	}
 }
@@ -41,12 +34,14 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::CollectData(APlayerController* 
 void FGameplayDebuggerCategory_GMCAbilitySystem::DrawData(APlayerController* OwnerPC,
 	FGameplayDebuggerCanvasContext& CanvasContext)
 {
+	const AActor* LocalDebugActor = FindLocalDebugActor();
+	const UGMC_AbilitySystemComponent* AbilityComponent = LocalDebugActor ? LocalDebugActor->FindComponentByClass<UGMC_AbilitySystemComponent>() : nullptr;
+	if (AbilityComponent == nullptr) return;
+	
 	if (!DataPack.ActorName.IsEmpty())
 	{
 		CanvasContext.Printf(TEXT("{yellow}Actor name: {white}%s"), *DataPack.ActorName);
-		const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn() ? OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>() : nullptr;
-		if (AbilityComponent == nullptr) return;
-
+		
 		// Abilities
 		CanvasContext.Printf(TEXT("{blue}[server] {yellow}Granted Abilities: {white}%s"), *DataPack.GrantedAbilities);
 		// Show client-side data


### PR DESCRIPTION
The GMAS gameplay debugger only shows information about the locally controlled actor and doesn't display information about the currently selected debug actor. This PR populates the replicated data with a selected DebugActor and also uses `FindLocalDebugActor()` to display client data.