### PR TITLE
Display selected actor's GMAS data in debugger

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -227,6 +227,22 @@ void UGMC_AbilitySystemComponent::RemoveAbilityMapData(UGMCAbilityMapData* Abili
 	}
 }
 
+void UGMC_AbilitySystemComponent::AddStartingEffects(TArray<TSubclassOf<UGMCAbilityEffect>> EffectsToAdd)
+{
+	for (const TSubclassOf<UGMCAbilityEffect> Effect : EffectsToAdd)
+	{
+		StartingEffects.AddUnique(Effect);
+	}
+}
+
+void UGMC_AbilitySystemComponent::RemoveStartingEffects(TArray<TSubclassOf<UGMCAbilityEffect>> EffectsToRemove)
+{
+	for (const TSubclassOf<UGMCAbilityEffect> Effect : EffectsToRemove)
+	{
+		StartingEffects.Remove(Effect);
+	}
+}
+
 void UGMC_AbilitySystemComponent::GrantAbilityByTag(const FGameplayTag AbilityTag)
 {
 	if (!GrantedAbilityTags.HasTagExact(AbilityTag))

--- a/Source/GMCAbilitySystem/Private/Debug/GameplayDebuggerCategory_GMCAbilitySystem.cpp
+++ b/Source/GMCAbilitySystem/Private/Debug/GameplayDebuggerCategory_GMCAbilitySystem.cpp
@@ -15,25 +15,18 @@ FGameplayDebuggerCategory_GMCAbilitySystem::FGameplayDebuggerCategory_GMCAbility
 
 void FGameplayDebuggerCategory_GMCAbilitySystem::CollectData(APlayerController* OwnerPC, AActor* DebugActor)
 {
-	if (OwnerPC)
+	if (DebugActor)
 	{
-		if (OwnerPC->GetPawn())
-		{
-			DataPack.ActorName = OwnerPC->GetPawn()->GetName();
+		DataPack.ActorName = DebugActor->GetName();
 
-			if (const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>())
-			{
-				DataPack.GrantedAbilities = AbilityComponent->GetGrantedAbilities().ToStringSimple();
-				DataPack.ActiveTags = AbilityComponent->GetActiveTags().ToStringSimple();
-				DataPack.Attributes = AbilityComponent->GetAllAttributesString();
-				DataPack.ActiveEffects = AbilityComponent->GetActiveEffectsString();
-				DataPack.ActiveEffectData = AbilityComponent->GetActiveEffectsDataString();
-				DataPack.ActiveAbilities = AbilityComponent->GetActiveAbilitiesString();
-			}
-		}
-		else
+		if (const UGMC_AbilitySystemComponent* AbilityComponent = DebugActor->FindComponentByClass<UGMC_AbilitySystemComponent>())
 		{
-			DataPack.ActorName = TEXT("Spectator or missing pawn");
+			DataPack.GrantedAbilities = AbilityComponent->GetGrantedAbilities().ToStringSimple();
+			DataPack.ActiveTags = AbilityComponent->GetActiveTags().ToStringSimple();
+			DataPack.Attributes = AbilityComponent->GetAllAttributesString();
+			DataPack.ActiveEffects = AbilityComponent->GetActiveEffectsString();
+			DataPack.ActiveEffectData = AbilityComponent->GetActiveEffectsDataString();
+			DataPack.ActiveAbilities = AbilityComponent->GetActiveAbilitiesString();
 		}
 	}
 }
@@ -41,11 +34,13 @@ void FGameplayDebuggerCategory_GMCAbilitySystem::CollectData(APlayerController* 
 void FGameplayDebuggerCategory_GMCAbilitySystem::DrawData(APlayerController* OwnerPC,
 	FGameplayDebuggerCanvasContext& CanvasContext)
 {
+	const AActor* LocalDebugActor = FindLocalDebugActor();
+	const UGMC_AbilitySystemComponent* AbilityComponent = LocalDebugActor ? LocalDebugActor->FindComponentByClass<UGMC_AbilitySystemComponent>() : nullptr;
+	if (AbilityComponent == nullptr) return;
+	
 	if (!DataPack.ActorName.IsEmpty())
 	{
 		CanvasContext.Printf(TEXT("{yellow}Actor name: {white}%s"), *DataPack.ActorName);
-		const UGMC_AbilitySystemComponent* AbilityComponent = OwnerPC->GetPawn() ? OwnerPC->GetPawn()->FindComponentByClass<UGMC_AbilitySystemComponent>() : nullptr;
-		if (AbilityComponent == nullptr) return;
 
 		// Abilities
 		CanvasContext.Printf(TEXT("{blue}[server] {yellow}Granted Abilities: {white}%s"), *DataPack.GrantedAbilities);

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -128,6 +128,12 @@ public:
 	UFUNCTION(BlueprintCallable, Category="GMAS|Abilities")
 	void RemoveAbilityMapData(UGMCAbilityMapData* AbilityMapData);
 
+	UFUNCTION(BlueprintCallable, Category="GMAS|Abilities")
+	void AddStartingEffects(TArray<TSubclassOf<UGMCAbilityEffect>> EffectsToAdd);
+
+	UFUNCTION(BlueprintCallable, Category="GMAS|Abilities")
+	void RemoveStartingEffects(TArray<TSubclassOf<UGMCAbilityEffect>> EffectsToRemove);
+
 	// Add an ability to the GrantedAbilities array
 	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	void GrantAbilityByTag(const FGameplayTag AbilityTag);


### PR DESCRIPTION
The GMAS gameplay debugger only shows information about the locally controlled actor and doesn't display information about the currently selected debug actor. This PR populates the replicated data with a selected DebugActor and also uses FindLocalDebugActor() to display client data.