### PR TITLE
Check Application Must/Must Not have tags for Effects

### DIFF
--- a/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
+++ b/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
@@ -56,8 +56,10 @@ void UGMCAbilityEffect::StartEffect()
 	bHasStarted = true;
 
 	// Ensure tag requirements are met before applying the effect
-	if( ( EffectData.MustHaveTags.Num() > 0 && !DoesOwnerHaveTagFromContainer(EffectData.MustHaveTags) ) ||
-		DoesOwnerHaveTagFromContainer(EffectData.MustNotHaveTags) )
+	if( ( EffectData.ApplicationMustHaveTags.Num() > 0 && !DoesOwnerHaveTagFromContainer(EffectData.ApplicationMustHaveTags) ) ||
+	DoesOwnerHaveTagFromContainer(EffectData.ApplicationMustNotHaveTags) ||
+	( EffectData.MustHaveTags.Num() > 0 && !DoesOwnerHaveTagFromContainer(EffectData.MustHaveTags) ) ||
+	DoesOwnerHaveTagFromContainer(EffectData.MustNotHaveTags) )
 	{
 		EndEffect();
 		return;
@@ -66,6 +68,8 @@ void UGMCAbilityEffect::StartEffect()
 	AddTagsToOwner();
 	AddAbilitiesToOwner();
 	EndActiveAbilitiesFromOwner(EffectData.CancelAbilityOnActivation);
+
+	bHasAppliedEffect = true;
 
 	// Instant effects modify base value and end instantly
 	if (EffectData.bIsInstant)
@@ -117,8 +121,8 @@ void UGMCAbilityEffect::EndEffect()
 		UpdateState(EGMASEffectState::Ended, true);
 	}
 
-	// Only remove tags and abilities if the effect has started
-	if (!bHasStarted) return;
+	// Only remove tags and abilities if the effect has started and applied
+	if (!bHasStarted || !bHasAppliedEffect) return;
 
 	if (EffectData.bNegateEffectAtEnd)
 	{

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -234,6 +234,7 @@ protected:
 
 private:
 	bool bHasStarted;
+	bool bHasAppliedEffect;
 
 	// Used for calculating when to tick Period effects
 	float PrevPeriodMod = 0;


### PR DESCRIPTION
The check for effect's Must/MustNot have tags was removed in a deepworld stability update:

https://github.com/reznok/GMCAbilitySystem/commit/0d653eb64b9b4b0cb3c8deba801e81dd4e39612e#diff-53cdacba9da8aa52bb5688e7631ff8619f7c51212f6f4f541f1e88787a3f44aeL57

The bool setting for `bHasStarted` was also moved in that change.

I've updated the check to once again include the application tag checks. I've also added a new bool that is only set if changes were made, that is then checked in EndEffect.