### PR TITLE
Allow for overriding block and cancel methods

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -170,6 +170,20 @@ void UGMCAbility::HandleTaskHeartbeat(int TaskID)
 	}
 }
 
+void UGMCAbility::CancelAbilities()
+{
+	for (const auto& AbilityToCancelTag : CancelAbilitiesWithTag) {
+		if (AbilityTag == AbilityToCancelTag) {
+			UE_LOG(LogGMCAbilitySystem, Warning, TEXT("Ability (tag) %s is trying to cancel itself, if you attempt to reset the ability, please use //TODO instead"), *AbilityTag.ToString());
+			continue;
+		}
+		
+		if (OwnerAbilityComponent->EndAbilitiesByTag(AbilityToCancelTag)) {
+			UE_LOG(LogGMCAbilitySystem, Verbose, TEXT("Ability (tag) %s has been cancelled by (tag) %s"), *AbilityTag.ToString(), *AbilityToCancelTag.ToString());	
+		}
+	}
+}
+
 void UGMCAbility::ServerConfirm()
 {
 	bServerConfirmed = true;
@@ -284,18 +298,9 @@ void UGMCAbility::BeginAbility()
 	
 	// Initialize Ability
 	AbilityState = EAbilityState::Initialized;
-
+	
 	// Cancel Abilities in CancelAbilitiesWithTag container
-	for (const auto& AbilityToCancelTag : CancelAbilitiesWithTag) {
-		if (AbilityTag == AbilityToCancelTag) {
-			UE_LOG(LogGMCAbilitySystem, Warning, TEXT("Ability (tag) %s is trying to cancel itself, if you attempt to reset the ability, please use //TODO instead"), *AbilityTag.ToString());
-			continue;
-		}
-		
-		if (OwnerAbilityComponent->EndAbilitiesByTag(AbilityToCancelTag)) {
-			UE_LOG(LogGMCAbilitySystem, Verbose, TEXT("Ability (tag) %s has been cancelled by (tag) %s"), *AbilityTag.ToString(), *AbilityToCancelTag.ToString());	
-		}
-	}
+	CancelAbilities();
 
 	// Execute BP Event
 	BeginAbilityEvent();

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -205,6 +205,8 @@ public:
 	// Prevent Abilities with these tags from activating when this ability is activated
 	FGameplayTagContainer BlockOtherAbility;
 
+	virtual void CancelAbilities();
+	
 	/** 
 	 * If true, activate on movement tick, if false, activate on ancillary tick. Defaults to true.
 	 * Should be set to false for actions that should not be replayed on mispredictions. i.e. firing a weapon

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -205,7 +205,7 @@ public:
 	int32 GetActiveAbilityCount(TSubclassOf<UGMCAbility> AbilityClass);
 
 	// Perform a check in every active ability against BlockOtherAbility and check if the tag provided is present
-	bool IsAbilityTagBlocked(const FGameplayTag AbilityTag) const;
+	virtual bool IsAbilityTagBlocked(const FGameplayTag AbilityTag) const;
 
 	UFUNCTION(BlueprintCallable, DisplayName="End Abilities (By Tag)", Category="GMAS|Abilities")
 	// End all abilities with the corresponding tag, returns the number of abilities ended


### PR DESCRIPTION
This shouldn't change anything but allow Cancel and Block functionality to be overwritten. Similar to https://github.com/reznok/GMCAbilitySystem/pull/74 this would allow ability tag relationships to be managed centrally